### PR TITLE
docs: drop stale 'until notarized releases ship' caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ Then click the display glyph in the menu bar.
 
 ### Option 2 — build from source
 
-The recommended path until signed/notarized releases ship — see
-[Building the macOS app](#building-the-macos-app-on-a-mac) below.
+Prefer to build it yourself? See [Building the macOS app](#building-the-macos-app-on-a-mac) below.
 
 ## Principles
 


### PR DESCRIPTION
Notarized releases have shipped; reword the build-from-source note as a plain alternative.