### PR TITLE
docs: planning + autonomy working docs (parity map, Batch-1 spec, playbook)

### DIFF
--- a/Docs/AUTONOMOUS_PROMPT.md
+++ b/Docs/AUTONOMOUS_PROMPT.md
@@ -1,0 +1,48 @@
+You are working autonomously on OpenDisplay (an Apple-Silicon-only macOS display manager) while I'm
+away for several hours. Build through the Batch 1 issues, verify each with the test suite, and commit
+green work as you go. Work safely and do not burn budget on dead ends.
+
+# Setup
+- Spec: read `docs/OpenDisplay-Issues-Batch-1.md` — six issues, each with acceptance criteria,
+  file/symbol pointers, and test steps.
+- State: read `PROGRESS.md` first to see what's done, and update it after every issue.
+- Branch: work on `batch1-auto` (create it if needed). Commit per issue. Do NOT push or open PRs.
+
+# SAFETY — hard rules, no exceptions
+- This session runs on the same Mac whose displays the app controls. NEVER execute real display
+  mutations to verify your work: no real disconnect/reconnect/recover, no applying real
+  resolutions/mirror/set-main, no DDC power-off, no blackout, no destructive `opendisplay` verbs.
+  Verify that behavior ONLY through `make test` (which uses the in-memory SimulatorProvider) and
+  non-destructive `--json` reads.
+- If an acceptance criterion needs real hardware, implement and unit-test the logic, mark that
+  criterion `[deferred: attended verification]` in PROGRESS.md, and still commit the code.
+- Do NOT modify the rescue app or the recovery path.
+- Clean-room: no BetterDisplay code, assets, UI, or copy — implement from first principles.
+
+# Verify
+- The gate for every issue is: `make test` passes green, exit 0, including new tests you add for that
+  issue's logic. Show the test output — "looks done" is not done. Keep `make lint` clean too.
+- Address root causes; never suppress or skip a failing test to get green.
+
+# Per-issue protocol — one issue at a time, in THIS order (safest / most self-contained first):
+#   3 (prevent-sleep) → 1 (DDC power) → 4 (URL scheme) → 2 (resolution slider) → 6 (arrangement safety gate) → 5 (auto-disconnect built-in)
+1. Read the issue. If it's one clear diff, implement directly. If it spans the codebase or you're
+   unsure, use a subagent to explore first so your own context stays lean.
+2. Implement, and add or extend unit tests for the logic.
+3. Run `make test`. If green and the acceptance criteria (minus any `[deferred]` hardware ones) are
+   met → commit with a clear message referencing the issue, update PROGRESS.md, move to the next.
+4. If it's not green after TWO focused attempts on the same issue: STOP that issue. Record what you
+   tried and the blocker in PROGRESS.md under "Tried / stuck", then move to the next issue. Do NOT
+   keep retrying the same thing — that wastes budget.
+
+# Stop cleanly (and write a final summary in PROGRESS.md) when any of these is true:
+- All six issues are done or deferred.
+- You reach an item that genuinely needs a human decision or real-hardware verification, with no
+  logic left to build.
+- You've gotten stuck on two separate issues — stop and summarize rather than grind.
+
+# Context hygiene
+- Pipe verbose build/test output to a file and grep for failures; don't paste full logs into context.
+- Prefer targeted tests while iterating; run the full `make test` before each commit.
+
+Begin by reading PROGRESS.md and docs/OpenDisplay-Issues-Batch-1.md, then start with Issue 3.

--- a/Docs/AUTONOMOUS_PROMPT.md
+++ b/Docs/AUTONOMOUS_PROMPT.md
@@ -3,9 +3,9 @@ away for several hours. Build through the Batch 1 issues, verify each with the t
 green work as you go. Work safely and do not burn budget on dead ends.
 
 # Setup
-- Spec: read `docs/OpenDisplay-Issues-Batch-1.md` — six issues, each with acceptance criteria,
+- Spec: read `Docs/OpenDisplay-Issues-Batch-1.md` — six issues, each with acceptance criteria,
   file/symbol pointers, and test steps.
-- State: read `PROGRESS.md` first to see what's done, and update it after every issue.
+- State: read `Docs/PROGRESS.md` first to see what's done, and update it after every issue.
 - Branch: work on `batch1-auto` (create it if needed). Commit per issue. Do NOT push or open PRs.
 
 # SAFETY — hard rules, no exceptions
@@ -15,7 +15,7 @@ green work as you go. Work safely and do not burn budget on dead ends.
   Verify that behavior ONLY through `make test` (which uses the in-memory SimulatorProvider) and
   non-destructive `--json` reads.
 - If an acceptance criterion needs real hardware, implement and unit-test the logic, mark that
-  criterion `[deferred: attended verification]` in PROGRESS.md, and still commit the code.
+  criterion `[deferred: attended verification]` in Docs/PROGRESS.md, and still commit the code.
 - Do NOT modify the rescue app or the recovery path.
 - Clean-room: no BetterDisplay code, assets, UI, or copy — implement from first principles.
 
@@ -30,12 +30,12 @@ green work as you go. Work safely and do not burn budget on dead ends.
    unsure, use a subagent to explore first so your own context stays lean.
 2. Implement, and add or extend unit tests for the logic.
 3. Run `make test`. If green and the acceptance criteria (minus any `[deferred]` hardware ones) are
-   met → commit with a clear message referencing the issue, update PROGRESS.md, move to the next.
+   met → commit with a clear message referencing the issue, update Docs/PROGRESS.md, move to the next.
 4. If it's not green after TWO focused attempts on the same issue: STOP that issue. Record what you
-   tried and the blocker in PROGRESS.md under "Tried / stuck", then move to the next issue. Do NOT
+   tried and the blocker in Docs/PROGRESS.md under "Tried / stuck", then move to the next issue. Do NOT
    keep retrying the same thing — that wastes budget.
 
-# Stop cleanly (and write a final summary in PROGRESS.md) when any of these is true:
+# Stop cleanly (and write a final summary in Docs/PROGRESS.md) when any of these is true:
 - All six issues are done or deferred.
 - You reach an item that genuinely needs a human decision or real-hardware verification, with no
   logic left to build.
@@ -45,4 +45,4 @@ green work as you go. Work safely and do not burn budget on dead ends.
 - Pipe verbose build/test output to a file and grep for failures; don't paste full logs into context.
 - Prefer targeted tests while iterating; run the full `make test` before each commit.
 
-Begin by reading PROGRESS.md and docs/OpenDisplay-Issues-Batch-1.md, then start with Issue 3.
+Begin by reading Docs/PROGRESS.md and Docs/OpenDisplay-Issues-Batch-1.md, then start with Issue 3.

--- a/Docs/OpenDisplay-Audit-Brief-for-ClaudeCode.md
+++ b/Docs/OpenDisplay-Audit-Brief-for-ClaudeCode.md
@@ -1,0 +1,60 @@
+# OpenDisplay — Repo Audit Brief (for Claude Code)
+
+**Goal:** replace inferred status with ground truth. The parity map
+(`OpenDisplay-Feature-Parity-Map.md`) marks each capability `✅ Have / 🟡 Partial / ⬜ Gap`, but those
+calls were inferred from the README, not the code. Audit the actual repo and correct them.
+
+**This pass is read + report only — do NOT build or change features.**
+
+---
+
+## Tasks
+
+### 1. Status pass
+For every capability in the parity map, open the relevant source and determine its real state. Record:
+- **Status:** `Have / Partial / Gap`
+- **Evidence:** file path(s) + function/type names that implement it (or confirm its absence)
+- **If Partial:** what's specifically missing to reach `Have`
+
+Give extra scrutiny to the rows flagged `🟡` or "Verify":
+- native brightness/volume media keys
+- resolution-slider UX (vs. discrete mode switching)
+- DDC over the **M1/M2 built-in HDMI** bus
+- the `VirtualDisplay` provider's actual state (functional vs. stub)
+- color adjustments via the existing gamma path
+- auto-disconnect-of-built-in on external connect (the trigger, not just the fall-back)
+- screen rotation (currently Labs/opt-in)
+
+### 2. Apple-Silicon-native confirmation  ← *Apple Silicon is the only supported target (locked); Intel is out of scope*
+Apple Silicon is the confirmed sole target — Intel support is explicitly not a goal. Verify the code
+matches that intent:
+- Confirm the core paths are cleanly AS-native — SkyLight disconnect, IOAVService DDC, CoreDisplay
+  calls, CGVirtualDisplay, DisplayServices brightness — with no dependence on anything Intel-only.
+- Flag any **vestigial or half-built Intel branches / cross-arch abstractions** that exist only to
+  straddle both architectures; these are removal candidates to shrink surface area (call them out —
+  do **not** delete in this read-only pass).
+- Note any place an AS-only assumption is implicit but unenforced (e.g. a missing arch guard) so it
+  can be made explicit later.
+
+### 3. Provider / architecture inventory
+List everything under `Providers/*` and what each actually implements today vs. stubs. Note which
+capabilities run through the safety-checked transaction path (`TopologyCore` / `SafetyEngine`) vs.
+bypass it.
+
+### 4. Quick-win confirmation
+Of the **Tier 1** items in the parity map (DDC input customization / power / auto-config, EDID export,
+display-name override, prevent-sleep-while-connected, basic keyboard shortcuts, favorite resolutions,
+HTTP + URL scheme, OSD, networked TV/AVR control, Night Shift for TVs), confirm which already have
+partial scaffolding to build on vs. which are true greenfield.
+
+---
+
+## Output
+
+- A **corrected status column** — update the parity map in place, or emit a delta table keyed to the
+  same feature names — with file/function evidence inline.
+- A short **"platform reality"** paragraph answering Task 2.
+- The **smallest 3–5 features to implement first**, given what scaffolding already exists.
+
+Keep evidence concrete (paths + symbols). Don't guess — if something is ambiguous, say so and point to
+the exact file to check.

--- a/Docs/OpenDisplay-ClaudeCode-Autonomy-Playbook.md
+++ b/Docs/OpenDisplay-ClaudeCode-Autonomy-Playbook.md
@@ -1,0 +1,271 @@
+# OpenDisplay — Claude Code Autonomy Playbook
+
+How to hand Batch 1 (and later batches) to Claude Code so it keeps shipping features with minimal
+intervention — adapted to OpenDisplay's specifics, not generic loop advice. Built from Anthropic's
+current Claude Code best-practices guidance plus the 2026 "loop engineering" community practice
+(Boris Cherny: *"my job is to write loops"*; Geoffrey Huntley's Ralph technique).
+
+---
+
+## 0. The model in one paragraph
+
+An autonomous run is a **doer + checker** loop, not a big prompt. A *doer* makes a change; a *checker*
+that the doer can't fake decides if it's done; the loop repeats until the check passes, then stops
+itself. Three things make it work: a **machine-checkable definition of done**, a **fresh context each
+iteration** (so the context window doesn't fill and degrade), and **external memory on disk** (so the
+fresh context knows what's already done). The single most important rule, straight from Anthropic:
+**give Claude a check it can run.** Everything below is in service of that.
+
+OpenDisplay is an unusually *good* fit for this because it already has three verification layers most
+projects lack — see §2.
+
+---
+
+## 1. ⚠️ The one hazard unique to OpenDisplay — read this first
+
+**The loop runs on the same Mac whose displays it modifies.** Several Batch 1 features
+(auto-disconnect built-in #5, resolution slider #2, the arrangement-safety work #6) can, if executed
+*for real* against the live desktop, blank or strand the very display this session is being watched
+on — and the audit already found that resolution/mirror/set-main bypass the SafetyEngine, so a bad
+real resolution can blank the only panel.
+
+**The rule that follows:** the autonomous loop verifies **logic**, never **live hardware mutation.**
+This is cheap for you because the architecture already separates them:
+
+- The disconnect/scene/resolution/safety **logic** is covered by `make test` (78 tests) against the
+  `SimulatorProvider` (in-memory, fault-injecting). The loop can fully exercise these features
+  **without touching a real display.**
+- **Real-hardware verification** (actually disconnecting a panel, applying a real mode, reading the
+  monitor back over the control MCP) is reserved for **attended** runs, ideally on a **secondary /
+  test display** rather than the primary panel — and never on the rescue/recovery path.
+
+So: let the loop run free on the *tested core + CLI surface*; keep the destructive real-display checks
+for when you're watching. The safety hook in §4 enforces this.
+
+---
+
+## 2. Your verification ladder (lean on it — it's your biggest advantage)
+
+| Layer | What it proves | Use in the loop? |
+|---|---|---|
+| `make test` (78 unit/state-machine tests, `SimulatorProvider`) | Feature **logic** is correct, deterministically, with no hardware | **Yes — primary gate.** Every iteration ends here. |
+| `opendisplay … --json` CLI read-back | Behavior through the real command surface (set X → read X back) | **Yes**, for non-destructive reads (brightness/info/state). Gate destructive verbs behind attended runs. |
+| Monitor-control MCP (read real display state) | The change actually took effect on hardware | **Attended only** — and reads, not destructive writes, when unattended. |
+
+Each Batch 1 issue already ends with a test step. **For the loop, the completion gate is: that
+issue's new/updated tests pass under `make test`, green, exit 0.** "Looks done" is not a signal; the
+green suite is.
+
+> Note: there is **no remote CI** in the repo today — `make test` is the gate, run locally. If you
+> want PR-based loops (§5, option C), add a tiny GitHub Action that runs `make test` on the
+> cross-platform packages (they build on Linux per the README), giving the loop a remote green check
+> for the non-macOS work. The macOS-hardware bits still verify locally/attended.
+
+---
+
+## 3. Externalize memory (the trick every long run depends on)
+
+Keep a `PROGRESS.md` at the repo root, committed each iteration. The fresh-context iteration reads it
+and knows what to do next. Minimum shape:
+
+```markdown
+# OpenDisplay autonomous progress
+## Done
+- (none yet)
+## In progress
+- Issue 1 (DDC power 0xD6): writing the Feature case + CLI verb
+## Tried / failed (so the next pass doesn't repeat it)
+- (none yet)
+## Next (Batch 1 order)
+1 → 2+6 → 3 → 4 → 5
+```
+
+This is what stops the loop from going in circles after a context reset — *the agent forgets, the repo
+doesn't.* The Batch 1 issues doc is the spec; `PROGRESS.md` is the running state.
+
+---
+
+## 4. One-time setup
+
+### a) CLAUDE.md (merge these into your existing one)
+
+Keep it short — Anthropic's guidance is that a bloated CLAUDE.md gets *ignored*. The high-value lines
+for autonomy here:
+
+```markdown
+# Build & verify
+- Test gate: `make test` (78 tests). Code is not done until this is green, exit 0.
+- Also: `make lint` (SwiftLint), `make xcode` (regen project), `swift build`.
+- Show evidence (test output / CLI JSON), never assert "done" without it. Fix root causes.
+
+# Platform
+- Apple Silicon only. No Intel. Private SPI stays behind `#if !PUBLIC_API_ONLY` + dlsym.
+
+# SAFETY — non-negotiable during unattended runs
+- NEVER execute real display disconnect/reconnect, resolution/mirror/set-main changes, or blackout
+  against the live desktop. Verify that logic via `make test` (SimulatorProvider) and non-destructive
+  `opendisplay --json` reads ONLY.
+- NEVER modify the rescue app or recovery path as part of feature work without explicit approval.
+- Gated ops route through TopologyCoordinator/SafetyEngine.
+
+# Boundaries
+- Clean-room: no BetterDisplay code, assets, UI, or copy. Implement from public docs / first
+  principles.
+- One Batch 1 issue at a time. Branch per issue. Commit only when `make test` is green. Update
+  PROGRESS.md every iteration.
+
+# Context hygiene
+- Pipe verbose build/test output to a file and grep failures; don't dump full logs into context.
+- On compaction, preserve: the current issue, the list of modified files, and the test command.
+```
+
+(Run `/init` first if you don't have one, then prune to the above.)
+
+### b) A reviewer subagent (the "checker" that isn't the "doer")
+
+`.claude/agents/parity-reviewer.md` — reviews each issue's diff in a **fresh context** against its
+acceptance criteria. Tell it to flag **only correctness/requirements gaps, not style** (a reviewer
+asked for gaps invents them; chasing all of them causes over-engineering — especially tempting in a
+safety-conscious codebase):
+
+```markdown
+---
+name: parity-reviewer
+description: Reviews a Batch 1 issue diff against its acceptance criteria
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+Review the current diff against the named issue's acceptance criteria. Confirm: every criterion is
+implemented; the new tests actually cover them; nothing outside the issue's scope changed; SAFETY
+rules in CLAUDE.md are respected (no live-hardware mutation paths added to unattended flows). Report
+only gaps affecting correctness or the stated requirements. Ignore style.
+```
+
+Anthropic also ships a bundled `/code-review` skill that does a fresh-context correctness review of
+the diff — fine to use instead.
+
+### c) A PreToolUse safety hook (enforces §1 deterministically)
+
+Hooks are deterministic where CLAUDE.md is only advisory. Have Claude write one
+(*"write a PreToolUse Bash hook that blocks `opendisplay disconnect|reconnect|scene apply|blackout`
+and any real display-reconfiguration command when running non-interactively"*). This guarantees the
+loop can't yank a live display even if a prompt drifts.
+
+### d) Permissions posture
+
+Use **auto mode**, not blanket bypass:
+
+```bash
+claude --permission-mode auto -p "…"
+```
+
+A classifier blocks scope-escalation/risky actions and lets routine work through; on `-p` runs it
+**aborts if it keeps blocking** (fails safe — good). Allowlist the safe surface so it doesn't stall:
+`Edit`, `Bash(make *)`, `Bash(swift *)`, `Bash(git *)`, `Bash(gh *)`. **Do not** hand a host-display
+session `--dangerously-skip-permissions` given §1.
+
+---
+
+## 5. Running the loop
+
+A single Claude run stops when it thinks it's done. To keep it going you need the **Stop-hook +
+completion-promise** pattern. Three ways, simplest first:
+
+**Option A — Ralph Wiggum plugin (recommended start).** Widely reported as an official Anthropic
+plugin; it installs the Stop hook that re-feeds the task with fresh context until a promise marker
+appears.
+
+```bash
+/plugin marketplace add anthropics/claude-code
+/plugin install ralph-wiggum@claude-plugin
+
+/ralph-loop "Implement Issue 1 from docs/OpenDisplay-Issues-Batch-1.md. Run `make test`. When that
+issue's tests pass green and its acceptance criteria are met, output <promise>DONE</promise>. Update
+PROGRESS.md." --max-iterations 10 --completion-promise "DONE"
+```
+
+Start with **one issue and `--max-iterations 10`** to calibrate cost/behavior, watch the first run,
+then scale up.
+
+**Option B — transparent bash fallback** (same idea, full visibility):
+
+```bash
+while :; do
+  claude -p "$(cat docs/OpenDisplay-Issues-Batch-1.md | sed -n '/Issue 1 —/,/Issue 2 —/p'). \
+Run make test. When this issue's tests pass green and acceptance criteria are met, output \
+<promise>DONE</promise>. Append progress to PROGRESS.md." \
+    --permission-mode auto \
+    --allowedTools "Edit,Bash(make *),Bash(swift *),Bash(git *),Bash(gh *)" \
+    --max-turns 30 \
+  | tee -a loop.log
+  grep -q "<promise>DONE</promise>" loop.log && break
+done
+```
+
+**Option C — PR-per-iteration** (if you add the Linux CI from §2): each iteration branches, commits,
+opens a PR via `gh`, waits for the `make test` check, and you (or an agent-team lead) merge. This
+keeps every change reviewable and respects branch protections.
+
+**Per-issue protocol** (whichever option): one issue → branch → implement → `make test` green →
+`parity-reviewer` subagent on the diff → fix gaps → commit → update `PROGRESS.md` → next issue.
+**Checkpoint per issue** — don't hand all six at once; a failure in #4 shouldn't burn the tokens of
+#5–6. Batch 1's order (1 → 2+6 → 3 → 4 → 5) is already set.
+
+> On Opus 4.8 the Ralph loop is less *necessary* than it was — the model follows a plan and manages
+> context far better, so well-specified small issues like these often converge in one or two passes.
+> Reach for the loop when an issue needs several attempts, not by default.
+
+---
+
+## 6. Cost & runaway guardrails (the $6k-overnight lesson)
+
+The headline cautionary tale: a Reddit user's 30-minute scheduled loop with no real stop condition ran
+up ~$6,000 overnight — because a short cache TTL meant an 800k-token context was rebuilt from scratch
+48×/day. Avoid that:
+
+- **Cap iterations.** `--max-iterations` (plugin) / `--max-turns` (CLI). Start at 10–15.
+- **Hard money ceiling.** Settings → Usage → set a monthly spend cap (or a workspace spend limit in
+  the Console on API). Enable **task budgets** (beta) for a soft per-workflow boundary.
+- **Keep loops tight, not scheduled-with-gaps.** Back-to-back iterations reuse the prompt cache;
+  long sleeps between wake-ups blow it away and re-bill the whole context. Don't put these small
+  issues on a 30-minute timer.
+- **A real stop condition every time** = the `<promise>` marker gated on green tests. Never "run until
+  it feels done."
+- **Context hygiene** (the real reason overnight runs die — they run out of *context*, not time):
+  fresh context per iteration (Ralph does this), suppress verbose logs, lean CLAUDE.md.
+
+These issues are small (hours to half-a-day each) and gated by a fast deterministic suite, so they
+converge cheaply — far lower risk than open-ended refactors. The danger scales with how open-ended
+the task is, which is exactly why we pre-cut them into tight specs.
+
+---
+
+## 7. What stays human-in-the-loop
+
+Resist the fully-unattended "dark factory." Keep yourself in the loop for:
+
+- **Real-hardware verification** of the destructive display features (§1) — attended, on a test panel.
+- **Merging to main** (or at least a spot-check of the recorded reviewer findings).
+- **The Tier 3/5 moat** later (flexible scaling, XDR/HDR, virtual screens, EDID override): these touch
+  private SPI and real display state and are poor first candidates for hands-off loops.
+- **Anything that would modify the rescue/recovery path.**
+
+The greenfield-but-self-contained Batch 1 items (DDC power, prevent-sleep, URL scheme) and the
+logic-testable ones are the safe autonomy targets. Start there.
+
+---
+
+## 8. Advanced (optional, later)
+
+For running the *whole batch* hands-off rather than issue-by-issue, Opus 4.8's **Dynamic Workflows**
+(research preview) moves the orchestration plan into a background JavaScript script instead of the
+context window — which is the constraint that breaks long multi-task runs. Worth a look once the
+per-issue Ralph loop is working reliably; it's the more advanced path, not the starting point.
+
+---
+
+### Sources
+Anthropic Claude Code best-practices & hooks docs (the verification rule, `/goal`, Stop-hook 8-block
+override, auto mode, subagents, `claude -p`); community "loop engineering" writing (Cherny, Huntley/
+Ralph, Osmani); the $6k-overnight and cache-TTL reports; Ralph Wiggum plugin write-ups. Verify command
+names against your installed Claude Code version — the surface is moving fast.

--- a/Docs/OpenDisplay-Feature-Parity-Map.md
+++ b/Docs/OpenDisplay-Feature-Parity-Map.md
@@ -1,0 +1,333 @@
+# OpenDisplay → BetterDisplay Feature Parity Map
+
+A complete inventory of BetterDisplay's feature surface (v4.x, as of June 2026), mapped against
+OpenDisplay's current capabilities, written as a planning + handoff document for Claude Code.
+
+Sources: BetterDisplay GitHub README, the official "List of free and Pro features" wiki matrix,
+and betterdisplay.pro. OpenDisplay status is taken from its README/PRD claims — see the caveat
+under *How to read this*.
+
+---
+
+## How to read this
+
+Each feature row carries four things:
+
+- **Feature** — the capability, described in neutral/functional terms.
+- **BD tier** — `Free` or `Pro` in BetterDisplay. (Pro is their paid moat; ~half the list.)
+- **OD status** — OpenDisplay today: `✅ Have` · `🟡 Partial` · `⬜ Gap`.
+- **Notes / API / difficulty** — the macOS surface it needs and rough effort.
+
+**Difficulty scale:** `trivial` → `low` → `medium` → `high` → `very high`. "Private API" means it
+depends on undocumented/private frameworks (CoreDisplay, SkyLight, DisplayServices, CGVirtualDisplay,
+IOAVService) — higher maintenance risk across macOS releases.
+
+> **Caveat on OD status:** these are mapped from OpenDisplay's README, not a line-by-line code audit.
+> Rows marked `✅` are explicitly claimed as functional there; `🟡` are present but Labs/experimental
+> or partial; `⬜` are not mentioned. A precise code-level audit (best done in Claude Code with repo
+> access) would tighten the `🟡`/`⬜` calls — flagged at the end.
+
+> **Clean-room reminder:** this is a map of *capabilities to match*, not BetterDisplay's code, UI,
+> assets, or copy. OpenDisplay's README already commits to clean-room/independent implementation;
+> every item below should be built from public docs + first-principles, keeping that line intact.
+
+---
+
+## 1. Brightness control
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Multi-method brightness (native + DDC + software) | Free | ✅ Have | DisplayServices (built-in), DDC/CI (external), gamma fallback. OD's core. |
+| Native brightness/volume media keys | Free | 🟡 Partial | Intercept F1/F2/volume keys, route to active display. Verify OD wires the media keys. `low` |
+| DDC brightness control | Free | ✅ Have | VCP 0x10 over I2C. |
+| Software dimming — colour-table (gamma) | Free | ✅ Have | CGSetDisplayTransferByTable. OD has gamma dimming. |
+| Software dimming — overlay | Free | ⬜ Gap | Black NSWindow at adjustable alpha above content. `low` |
+| Combined dimming (gamma + overlay) | Free | ⬜ Gap | Chain the two to go darker than either alone. `low` |
+| Dimming to black / "Black Out" | Free | ✅ Have | OD has Black Out. |
+| Basic brightness syncing across displays | Free | ⬜ Gap | Broadcast one slider to a group. Needs a grouping model (§12). `low–medium` |
+| Advanced brightness & image-adjustment syncing | Pro | ⬜ Gap | Sync brightness + contrast + colour together. `medium` |
+| Nits-based normalized brightness syncing | Pro | ⬜ Gap | Needs a per-display nits model so "300 nits" means the same on each panel. `high` |
+
+## 2. XDR / HDR extra-brightness upscaling — *BetterDisplay's signature pillar*
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Color-table XDR/HDR upscaling (Apple Silicon) | Pro | ⬜ Gap | Private gamma/EDR manipulation. Hardware-gated (XDR/HDR panels). `very high, private API` |
+| Metal XDR/HDR upscaling (AS + Intel) | Pro | ⬜ Gap | EDR-enabled Metal layer + shader pushing values >1.0. `very high` |
+| Direct XDR upscaling (AS, macOS 26.3+) | Pro | ⬜ Gap | Newest private path on 26.3+. `very high, private API` |
+| Native XDR upscaling (AS, ≤ macOS 26.2) | Pro | ⬜ Gap | Older private brightness path. `very high, private API` |
+| Upscale to ~1600 nits on XDR panels | Pro | ⬜ Gap | The headline number; output of the methods above. |
+| External HDR display brightness boost | Pro | ⬜ Gap | Display-dependent (DisplayHDR 600+). |
+| HDR extra-brightness calibration | Pro | ⬜ Gap | Per-display calibration UI on top of upscaling. `high` |
+| Third-party HDR extra brightness | Pro | ⬜ Gap | Extends boost to non-Apple HDR panels. `high` |
+
+> This whole block is the hardest, most macOS-version-fragile, and most hardware-specific part of
+> BetterDisplay. Realistically a late-stage target, not an early win.
+
+## 3. Color management
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Color-mode selector — RGB / YCbCr / chroma subsampling / HDMI range (AS) | Free | ⬜ Gap | Private CoreDisplay pixel-encoding + range APIs. `high, private API` |
+| Color adjustments (per-channel) | Pro | 🟡 Partial | Extend OD's existing gamma-table path to RGB channels. `medium` |
+| Color temperature control | Pro | ⬜ Gap | Warm/cool via gamma. Builds on §1 gamma path. `medium` |
+| Color-profile (ICC) selector | Free | ✅ Have | OD does per-display ICC via ColorSync. |
+| SDR/HDR color-profile auto-switch | Pro | ⬜ Gap | Detect HDR engage/disengage, swap profile. `medium` |
+
+## 4. DDC / hardware control
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| DDC support across most Macs | Free | ✅ Have | OD has DDC/CI layer. |
+| DDC over M1/M2 built-in HDMI | Free | 🟡 Verify | BD's unique selling point. Confirm OD reaches the built-in HDMI I2C bus on AS. `medium` |
+| DDC over Intel 2018 mini built-in HDMI | Free | ⬜ Gap | Intel-only edge; low priority if OD is AS-first. `medium` |
+| DDC brightness | Free | ✅ Have | VCP 0x10. |
+| DDC volume | Free | ✅ Have | VCP 0x62. |
+| DDC input switching | Free | ✅ Have | VCP 0x60. OD lists input source. |
+| DDC input customization (label/define inputs) | Free | ⬜ Gap | UI to name/whitelist input codes per display. `low` |
+| DDC power control (on/standby/off) | Free | ⬜ Gap | VCP 0xD6. `low` |
+| DDC capabilities + auto-config | Free | ⬜ Gap | Read/parse VCP capabilities string, auto-detect supported controls. `medium` |
+| DDC + color control over DisplayLink | Free | ⬜ Gap | DisplayLink path is separate from native DDC. `medium` |
+| DDC color preset selection | Free | ✅ Have | VCP 0x14. OD lists colour preset. |
+
+## 5. Networked TV / AVR control
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| LG webOS TV control | Free | ⬜ Gap | webOS WebSocket (SSAP) protocol. `medium, no private API` |
+| Samsung Tizen TV control | Free | ⬜ Gap | Tizen WebSocket / SmartThings. `medium` |
+| Philips Android TV control | Free | ⬜ Gap | JointSpace HTTP API. `medium` |
+| Yamaha AVR control | Free | ⬜ Gap | YNCA / HTTP control. `medium` |
+| Night Shift for TVs | Free | ⬜ Gap | Apply Night Shift / colour shift to external/TV via CoreBrightness. `medium` |
+
+> Entirely self-contained network protocols — **no private macOS APIs, no hardware gating**. A clean,
+> shippable module that can be built and tested brand-by-brand. Good morale/feature-count wins.
+
+## 6. Resolution / scaling / HiDPI
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Custom scaled-resolution editing | Free | ✅ Have | OD does resolution switching. |
+| **Flexible HiDPI scaling** (notch/HDR/HDCP/high-refresh) | Pro | ⬜ Gap | **The flagship.** Synthesize arbitrary scaled HiDPI modes (often via mode injection / EDID override). `very high, private API` |
+| Native / default resolution editing | Free | ✅ Have | CGDisplay mode set. |
+| Display-mode selector menu | Free | ✅ Have | Mode enumeration + menu. |
+| Refresh-rate selector menu | Free | ✅ Have | Part of OD mode switching. |
+| Unexposed + NTSC (59.94 etc.) refresh rates (AS) | Free | ⬜ Gap | Surface hidden CoreDisplay modes. `medium, private API` |
+| Resolution slider | Free | 🟡 Partial | Continuous slider over the mode ladder. OD has switching; confirm slider UX. `low` |
+| Create custom HiDPI resolutions for real displays | Free→Pro | ⬜ Gap | Manual mode authoring; overlaps flexible scaling. `high` |
+| Favorite resolutions (menu / slider / shortcut) | Pro | ⬜ Gap | Persist + quick-recall presets. `low` |
+| Screen-rotation menu | Free | 🟡 Partial | OD has rotation in Labs (opt-in). Promote out of Labs. `medium` |
+| Resolution syncing / UI-scale matching | Pro | ⬜ Gap | Match logical UI scale across displays. `medium` |
+| Forced-HDR mode to unlock resolution limits | Pro | ⬜ Gap | Toggle HDR to access higher modes/refresh. `high, private API` |
+| Hi-quality Zoom + screenshots on 1080p | Free | ⬜ Gap | Byproduct of HiDPI backing scale. Comes with flexible scaling. |
+
+## 7. Display disconnect / reconnect — *OpenDisplay's core strength*
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Soft disconnect / reconnect displays | Pro | ✅ Have | OD's defining capability, with independent recovery (see §16). SkyLight. |
+| Auto-disconnect built-in screen on external connect | Pro | 🟡 Partial | OD has auto fall-back to built-in; confirm the *auto-disconnect-on-connect* trigger + UI. `low` |
+| Prevent sleep while a display is connected | Pro | ⬜ Gap | IOPMAssertion (kIOPMAssertionTypePreventUserIdleDisplaySleep). `low` |
+
+## 8. Virtual screens
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Virtual-screen creation | Free | 🟡 Partial | CGVirtualDisplay (private). OD has a VirtualDisplay provider in Labs. `medium, private API` |
+| Virtual-screen association (bind to a real output) | Free | 🟡 Partial | Pairing logic on top of creation. `medium` |
+| Custom virtual screens (arbitrary res/aspect) | Pro | ⬜ Gap | Parametrized creation UI. `high` |
+| HDR virtual screens (+ high-refresh) | Pro | ⬜ Gap | HDR-capable virtual mode (compatible Macs). `high, private API` |
+| Headless-Mac support for remote access | Free | ⬜ Gap | Derived from virtual screens (no panel attached). |
+| Scaled / portrait Sidecar via virtual-screen streaming | Pro | ⬜ Gap | Needs virtual screen + streaming (§9). `high` |
+
+## 9. Picture-in-Picture / streaming / video filters — *whole subsystem*
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Picture-in-Picture window of any display/virtual screen | Pro | ⬜ Gap | ScreenCaptureKit capture → floating window. `high` |
+| Video-filter window | Pro | ⬜ Gap | Metal render pass over captured stream. `high` |
+| Full-screen video filters | Pro | ⬜ Gap | Filter applied to whole screen via self-stream. `high` |
+| Full-screen streaming (display → another screen) | Pro | ⬜ Gap | Local stream redirect. `high` |
+| Stream/PIP stretching + off-centering | Pro | ⬜ Gap | Geometry transforms on the stream. `medium` (once subsystem exists) |
+| Stream/PIP rotation (+ portrait Sidecar) | Pro | ⬜ Gap | Rotated render. `medium` |
+| Stream/PIP crop | Pro | ⬜ Gap | Crop rect on capture. `medium` |
+| Teleprompter mode (stream flip) | Pro | ⬜ Gap | Horizontal mirror of stream. `low` (once subsystem exists) |
+| Off-center streaming (bottom-half-of-TV widescreen) | Pro | ⬜ Gap | Position a cropped stream region. `medium` |
+| Self-streaming (apply filters to own screen) | Pro | ⬜ Gap | Loopback capture + filter. `high` |
+
+> One cohesive pillar: **ScreenCaptureKit (capture) + Metal (render/filter) + window management.**
+> Build the capture→render→window spine once; the ~10 sub-features above are then mostly geometry
+> and filter variations on top. All public APIs — effort is high but risk is low.
+
+## 10. Mirroring
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Mirror configuration (build mirrored sets) | Pro | ✅ Have | OD has mirroring + a reversible CG fallback. |
+| Mirror protection (keep a mirror set intact) | Pro | ⬜ Gap | Re-apply mirror state on change — aligns with OD's desired-state model. `medium` |
+| Simplify creating mirrored sets (UI) | Pro | 🟡 Partial | UX layer over existing mirroring. `low` |
+
+## 11. EDID
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| EDID retrieval / export | Free | ⬜ Gap | IORegistry `IODisplayEDID` read + export. `low–medium` |
+| Detailed display information panel | Free | 🟡 Partial | Surface registry/CoreDisplay metadata in UI. `low` |
+| Display-name override | Free | ⬜ Gap | Alias at app level, or CoreDisplay/registry naming. `low` |
+| EDID override (Apple Silicon) | Pro | ⬜ Gap | CoreDisplay override path. `very high, private API` |
+| EDID override (Intel) | Pro | ⬜ Gap | Display-override plist approach; SIP-sensitive. `very high` |
+
+## 12. Display-config protection / layout / groups
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Display-config protection (res / refresh / VRR / rotation / profile) | Pro | 🟡 Partial | Watch for drift, re-apply desired state. **Directly leverages OD's scene/safety engine.** `medium` |
+| Layout protection with anchor points | Pro | ⬜ Gap | Persist arrangement + re-apply on reconnect. Aligns with scenes. `medium–high` |
+| Advanced layout management | Pro | ⬜ Gap | Richer multi-display arrangement tooling. `medium–high` |
+| Custom display groups | Pro | ⬜ Gap | Grouping model feeding syncing (§1) + controls. `medium` |
+| Display group + synchronization (basic) | Free | ⬜ Gap | The basic sync atop grouping. `low–medium` |
+| Move displays relative to each other from the menu | Free | ✅ Have | OD has the drag-to-arrange canvas. |
+
+> OD's existing scene engine (desired-state diff/plan/idempotency) makes this category *cheaper for
+> OpenDisplay than it was for BetterDisplay* — protection is "re-assert a saved scene on change."
+
+## 13. Keyboard shortcuts
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Native brightness/volume keys | Free | 🟡 Partial | See §1 media-key row. |
+| Basic custom keyboard shortcuts | Free | ⬜ Gap | Global hotkey registration → actions. `low` |
+| Advanced custom keyboard shortcuts | Pro | ⬜ Gap | Per-display / per-action / chained shortcuts. `medium` |
+| Shortcuts for brightness + audio | Free | ⬜ Gap | Specific bindings on the above. `low` |
+
+## 14. On-screen display (OSD)
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Native / native-looking OSD | Free | ⬜ Gap | Floating HUD window on brightness/volume change. `medium` |
+| OSD nits output (show nits, not %) | Pro | ⬜ Gap | Needs nits model (§1). `medium` |
+| Custom OSD styles (+ classic-on-Tahoe) | Free | ⬜ Gap | Theming layer over the OSD. `low` |
+| External HUD / notch-app integration API | Free | ⬜ Gap | Publish OSD events (distributed notification dispatch) so notch apps can render them. `low` |
+
+## 15. Automation / integration / CLI
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Command-line integration | Free | ✅ Have | OD ships the `opendisplay` CLI on the safety-checked path. |
+| Custom integration + DDC controls (scriptable) | Pro | 🟡 Partial | Expose arbitrary DDC/actions to scripts. `medium` |
+| Control integration via shell scripts + URLs | Free | 🟡 Partial | OD CLI covers shell; add URL triggers. `low` |
+| macOS Shortcuts (App Intents) | Free | ✅ Have | OD has Shortcuts/Siri intents. |
+| HTTP server + custom URL scheme | Free | ⬜ Gap | `opendisplay://` handler + small embedded HTTP listener. `low–medium` |
+| Notifications (on events) | Free | ⬜ Gap | UserNotifications on config/display events. `low` |
+| Raycast extension | 3rd-party | ⬜ N/A | Community could build one once CLI/URL surface is stable. |
+
+## 16. Eye care / misc / platform
+
+| Feature | BD tier | OD status | Notes / API / difficulty |
+|---|---|---|---|
+| Reduce PWM / temporal-dithering flicker | Free | ⬜ Gap | Disable dithering / nudge brightness method per panel. `medium, private API` |
+| Localization | — | ⬜ Gap | String catalogs + community translation. `low, ongoing` |
+| Homebrew cask | — | ⬜ Gap | Distribution convenience. `trivial` |
+| Menu-bar app, no Dock icon | — | ✅ Have | OD is already a menu-bar agent. |
+| Signed + notarized distribution | — | ✅ Have | OD ships Developer-ID-signed + notarized. |
+| Trial + Pro licensing | — | ⬜ N/A | OD is GPL/free — not applicable, and a positioning advantage. |
+
+---
+
+## Where OpenDisplay already *leads* BetterDisplay
+
+Worth keeping visible — these are differentiators to lean into, not gaps:
+
+- **Scenes** — true desired-state snapshots with diff/plan/idempotency. BetterDisplay only has
+  config *protection*, not a first-class scene engine.
+- **Independent recovery** — a separate signed rescue app + global hotkey, with an
+  always-one-display-active guarantee and auto fall-back to the built-in panel. BetterDisplay leans
+  on its own UI to undo a bad state.
+- **Explicit safety model** — observed-vs-desired state tracking, and outcomes verified via OS
+  events/read-back or reported as `unverified` rather than assumed.
+- **Audited, unified automation path** — CLI, Shortcuts, and the UI all drive the *same*
+  safety-checked path.
+- **Universal software fallback** — gamma dimming even below the panel's hardware minimum.
+- **Open source (GPL)** vs a paid/closed model.
+
+---
+
+## Suggested build order (handoff tiers)
+
+Grouped by risk/effort so Claude Code can take a tier at a time. The principle: **broaden the free-tier
+parity with low-risk, no-private-API wins first; defer the hardware-gated and private-API moat.**
+
+**Tier 0 — already done (the free-tier core).** Brightness (3 methods), DDC hardware controls, ICC
+profiles, mode/refresh/HiDPI switching, mirroring, dimming/Black Out, soft disconnect + recovery,
+scenes, CLI, Shortcuts.
+
+**Tier 1 — low-risk standalone wins (no private APIs, mostly free-tier parity):**
+DDC input customization · DDC power · DDC capabilities/auto-config · display-name override ·
+EDID retrieval/export · prevent-sleep-while-connected · basic + brightness/audio keyboard shortcuts ·
+favorite resolutions · resolution slider polish · HTTP + URL scheme · notifications · native-looking
+OSD + custom styles + notch-app integration API · **networked TV/AVR control (LG, Samsung, Philips,
+Yamaha)** · Night Shift for TVs · mirror protection · display-config protection *(rides the scene engine)*.
+
+**Tier 2 — medium, builds on the existing engine:**
+display groups + brightness syncing (basic → advanced) · color adjustments + color temperature
+*(extend gamma)* · SDR/HDR profile auto-switch · layout protection / anchor points / advanced layout ·
+unexposed + NTSC refresh rates · advanced keyboard shortcuts · DisplayLink DDC.
+
+**Tier 3 — high effort / private API (the resolution moat):**
+**flexible HiDPI scaling (flagship)** · color-mode selector (RGB/YCbCr/chroma/HDMI range) ·
+virtual screens (basic → custom → HDR) + headless · forced-HDR mode · EDID override (AS → Intel).
+
+**Tier 4 — streaming subsystem (new pillar, public APIs):**
+build the ScreenCaptureKit→Metal→window spine, then PIP · local/full-screen streaming · video filters ·
+stretch/off-center/crop/rotate · teleprompter · scaled/portrait Sidecar.
+
+**Tier 5 — hardware-gated, hardest, most fragile:**
+XDR/HDR brightness upscaling (color-table, Metal, direct, native) · HDR calibration · third-party HDR
+brightness · nits-based normalized syncing · OSD nits output *(all depend on the nits model)*.
+
+---
+
+## Decisions (locked) & status corrections — post-audit
+
+**Decisions resolved:**
+
+1. **Platform: Apple Silicon only.** Intel is explicitly out of scope. The Intel rows above
+   (DDC over the 2018 mini HDMI, EDID override (Intel)) are **dropped** — ignore them. Audit confirms
+   the core is cleanly AS-native with no Intel-only code; the only cleanup is vestigial cross-arch
+   *build* surface (no `arm64` pin in `project.yml` → it's building universal; dead `#else` arch
+   branches; runtime-not-compile-time AS guard).
+2. **Private APIs / reverse engineering: in scope.** Tiers 3/5 may use reverse-engineered *Apple*
+   frameworks (distinct from the BetterDisplay clean-room line). Accepted costs: cross-version
+   fragility + no Mac App Store (irrelevant — ships notarized via GitHub under GPL).
+3. **Audit: complete.** Ground-truth statuses below supersede the inferred `🟡`/`⬜` cells in the
+   tables above.
+4. **Issues: in progress.** Batch 1 (5 quick wins + 1 safety hardening) is written — see
+   `OpenDisplay-Issues-Batch-1.md`. That doc + the live repo are now the source of truth for active
+   work; the tables above are the strategic overview.
+
+**Status corrections from the repo audit (these override the cells above):**
+
+- **Already shipped (✅), do not rebuild:** DDC *input customization* (VCP `0x60`, with UI + CLI) and
+  *display-name override* (alias, persisted, UI + CLI). Both were marked `⬜` above — they're done.
+- **DDC over the M1/M2 built-in HDMI: confirmed working (✅)** for a single external via
+  `IOAVService`/`DCPAVServiceProxy` (`Location=="External"`). **Caveat:** multi-display
+  disambiguation is by enumeration order, not EDID → wrong-monitor risk with several *identical*
+  externals (a real follow-up).
+- **Virtual screens AND PIP/streaming are bare stubs (⬜ greenfield), not partial.**
+  `VirtualDisplayProvider` and `CaptureProvider` are ~17-line stubs; `CGVirtualDisplay` /
+  ScreenCaptureKit aren't used anywhere. Budget these as full new subsystems.
+- **Native media keys: full gap (⬜).** Brightness/volume are app-UI only; nothing intercepts the
+  F1/F2/volume keys today (the one global hotkey is ⌃⌥⌘R for Reconnect-All).
+- **Auto-disconnect-on-external-connect: only the fall-back exists (⬜ trigger).** The "external
+  arrived → turn off built-in" watcher isn't wired; the disconnect mechanism + safety net are. This
+  is the project's original use case — small to finish (Batch 1, Issue 5).
+- **Color via gamma: ⬜ as gamma** (the gamma call is a uniform all-channel scale = dim/black-out
+  only), but it already takes per-channel RGB args → trivial to generalize for color-temp/RGB.
+  Overall color is ✅ via ICC + DDC preset.
+
+**⚠️ Architectural finding worth a decision:** only logical disconnect/reconnect is gated by the
+SafetyEngine. **Set-main, mirror, and resolution changes alter the active arrangement but bypass it.**
+A bad resolution/mirror can leave a display unreadable while still technically "active," so it doesn't
+get the checkpoint/independent-recovery guarantee disconnect does — which rubs against the project's
+own *safety-before-capability* principle, and gets more exposed once the resolution slider lands.
+Captured as Batch 1's safety-hardening issue (timed auto-revert).

--- a/Docs/OpenDisplay-Issues-Batch-1.md
+++ b/Docs/OpenDisplay-Issues-Batch-1.md
@@ -1,0 +1,185 @@
+# OpenDisplay — Batch 1 Issues (ready to file)
+
+Six issues for the first build pass: **five quick wins** the audit confirmed have the most existing
+scaffolding, plus **one safety-hardening item** the audit surfaced. Each is self-contained — paste as
+a GitHub issue, or point Claude Code at this file.
+
+Target: **Apple Silicon only.** Line/symbol references are from the repo audit. Where a feature has a
+private-SPI path, keep it behind the existing `#if !PUBLIC_API_ONLY` gate and `dlsym` resolution so
+the public-API build still compiles and degrades gracefully.
+
+Suggested order: **#1, #2 + #6 together, #3, #4, #5.** (#6 should land with or just before the
+resolution slider in #2.)
+
+---
+
+## Issue 1 — Add DDC power control (VCP `0xD6`)
+
+**Type:** feature · **Effort:** ~hours · **Risk:** low
+
+**Current state.** The full DDC read/write/coalesce path exists (`DDCControl.swift`), but the `Feature`
+enum has no `0xD6` case. Sibling controls (input `0x60`, color preset `0x14`) are already wired end to
+end, so this is a copy of an established pattern.
+
+**Acceptance criteria.**
+- A `Feature`/VCP case for power mode (`0xD6`) is added to `DDCControl.swift`.
+- `AppModel` exposes `setPowerMode(_:)` alongside `setInputSource` (`AppModel.swift:134`, `:806`).
+- Menu item under the display's DDC controls (near `DisplayDetailView.swift:204`) offering **On /
+  Standby / Off**.
+- CLI verb `opendisplay ddc … power <on|standby|off>` mirroring the existing `ddc … input` verb.
+- Sends are best-effort and never crash if the display NAKs or ignores the write.
+
+**Implementation pointers.** Standard DPM values for `0xD6`: `0x01` On, `0x04` Off (DPMS), `0x05` Off
+(hard). Exact accepted values vary by display — read them from the capabilities string where available
+rather than assuming (ties into a future auto-config issue).
+
+**Testing.** Send Standby/Off → panel powers down; send On → wakes (note: many displays can't be woken
+over DDC once off — document and handle gracefully). Verify via read-back where the display supports it.
+
+---
+
+## Issue 2 — Replace the resolution dropdown with a slider
+
+**Type:** feature (UI) · **Effort:** ~hours · **Risk:** low · **Companion:** #6
+
+**Current state.** The backend is done — `CoreGraphicsProvider.swift:394 availableModes` returns one
+mode per point-size, area-sorted, and `setMode` works. The UI renders a discrete `Menu`
+(`DisplayDetailView.swift:85-99`), not a slider. Comments already assume a slider
+(`AppModel.swift:633`), so this closes an intended-but-unfinished path.
+
+**Acceptance criteria.**
+- The resolution `Menu` in `DisplayDetailView.swift:85-99` is replaced by a `Slider` bound to the
+  index into the area-sorted `availableModes`.
+- Dragging the slider applies via `setMode`; the current mode is reflected as the slider position.
+- The active stop's label shows resolution (and refresh / HiDPI where relevant).
+- Single-mode displays hide or disable the slider (no dead control).
+
+**Implementation pointers.** Pure UI/binding change; do not touch the provider. Index discipline must
+match the area-sort so stops are monotonic.
+
+**Testing.** Slider steps through every mode in order; selecting applies and lands on the correct mode;
+verify the edge case of one-mode displays.
+
+**Note.** Pair with #6 — a slider makes it trivial to slam through modes, so the timed auto-revert
+safety gate should be in place when this ships. Commit-on-release + revert prompt.
+
+---
+
+## Issue 3 — Prevent display sleep while an external is connected
+
+**Type:** feature · **Effort:** ~half day · **Risk:** low
+
+**Current state.** No `IOPMAssertion` anywhere in the tree; `SettingsStore.swift` currently holds three
+keys. Greenfield but small and self-contained.
+
+**Acceptance criteria.**
+- A new `SettingsStore` toggle (default off) + a menu item.
+- While the toggle is on **and** ≥1 external display is present, hold an
+  `IOPMAssertionCreateWithName` of type `kIOPMAssertionTypePreventUserIdleDisplaySleep`.
+- The assertion is released when the last external is removed, or the toggle is turned off.
+- No leaked assertions across connect/disconnect cycles or app relaunch.
+
+**Implementation pointers.** Hook external-presence transitions in `observeTopologyChanges`
+(`AppModel.swift:1071-1090`); store the assertion handle on the model; release symmetrically.
+
+**Testing.** Enable + external connected → display doesn't idle-sleep; disconnect or disable → assertion
+gone. Verify with `pmset -g assertions`.
+
+---
+
+## Issue 4 — `opendisplay://` URL-scheme automation
+
+**Type:** feature · **Effort:** ~half day · **Risk:** low–medium (external trigger — see security note)
+
+**Current state.** No `CFBundleURLTypes`, no `onOpenURL`, no HTTP listener. But a safe command surface
+already exists and is reused by two front ends: the `opendisplay` CLI (`main.swift`:
+list/disconnect/reconnect/recover/scene/brightness/ddc, `--json`) and App Intents/Siri
+(`OpenDisplayIntents.swift`) — both routing through the same `CommandGateway`. This issue is just a
+third front door onto that gateway.
+
+**Acceptance criteria.**
+- `CFBundleURLTypes` registered for `opendisplay://` in the app `Info.plist`.
+- `.onOpenURL` parses the URL and maps it onto existing `CommandGateway` commands.
+- Every action goes through the **same** safety-checked/audited path as the CLI (an audit entry
+  appears).
+- Malformed or unknown URLs are a logged no-op, never a crash.
+- **Scope:** URL scheme only. The embedded HTTP listener is a separate later issue.
+
+**Implementation pointers.** Mirror the CLI verb table (`main.swift`) in a small URL→command mapper;
+reuse `CommandGateway` rather than re-implementing actions.
+
+**Security note.** URL handlers can be invoked by any app or web link. Expose only the safe command
+surface; anything destructive or arrangement-altering must require explicit in-app confirmation, not
+fire silently from a URL. Do not accept arbitrary parameters that bypass the gateway's checks.
+
+**Testing.** `open "opendisplay://reconnect-all"` (and a few others) trigger the action; a malformed URL
+is ignored with a log line; confirm routing via the audit trail.
+
+---
+
+## Issue 5 — Auto-disconnect the built-in panel when an external connects
+
+**Type:** feature · **Effort:** ~half day · **Risk:** low (mechanism + safety already exist)
+**This is the project's original use case, made automatic.**
+
+**Current state.** Only the fall-back exists: `enforceActiveSurfaceInvariant` fires when **0** displays
+are active (the re-enable safety net), `AppModel.swift:1071-1090`. Nothing watches "external arrived →
+turn off built-in." Manual disconnect, `setDisplayActive`, and the `SafetyEngine` are all in place.
+
+**Acceptance criteria.**
+- A policy toggle (default **off**) + menu item.
+- When on, an external-arrival transition (detected in `observeTopologyChanges`) calls the existing
+  `setDisplayActive(false)` on the **built-in**, routed through the gated
+  `TopologyCoordinator`/`SafetyEngine` path.
+- When the external later disappears, the built-in returns (the existing safety net already covers
+  this — verify, don't duplicate).
+- Connecting a **second** external does not re-trigger; turning the toggle off restores normal
+  behavior.
+
+**Implementation pointers.** Transition detection only — reuse `setDisplayActive(false)` and the
+existing gated path; add the `SettingsStore` key. Do not add a new disconnect mechanism.
+
+**Testing.** Toggle on + connect external → built-in turns off, external stays; disconnect external →
+built-in returns; second external → no re-trigger; toggle off → no auto behavior.
+
+---
+
+## Issue 6 — Safety gate for arrangement-altering changes (timed auto-revert)
+
+**Type:** safety hardening · **Effort:** ~0.5–1 day · **Risk:** low · **Recommended before/with #2**
+
+**Why.** The audit found that only logical disconnect/reconnect is gated by the `SafetyEngine`.
+**Set-main, mirror, and resolution changes alter the active arrangement but bypass it** — they're
+applied directly (`CoreGraphicsProvider` / `DDCControl`). A bad resolution or mirror change can leave a
+display unreadable while it's still technically "active," so it doesn't get the checkpoint/independent
+-recovery guarantee that disconnect does. This contradicts the project's *safety-before-capability*
+principle, and the incoming resolution slider (#2) makes it easy to trigger.
+
+**Acceptance criteria.**
+- Resolution, mirror, and set-main changes are wrapped in a checkpoint with a **macOS-style timed
+  auto-revert**: apply → prompt "Keep these settings? Reverting in N seconds" → revert to the prior
+  state unless confirmed.
+- Revert restores the exact prior arrangement (mode/origin/mirror/main).
+- The confirmation surface is reachable even if the *changed* display became unreadable (e.g. prompt
+  shown on a still-good display, and/or confirmable via the existing global hotkey / rescue path).
+- Consistent with the existing rotation marker/rollback pattern (`AppModel.swift:889`) — reuse it
+  rather than inventing a parallel mechanism.
+
+**Implementation pointers.** Extend the checkpoint/rollback approach rotation already uses; the
+`SafetyEngine` + audit trail are the right home. Decide whether to route these ops through the gateway
+or keep them direct-but-checkpointed — either is fine as long as the revert is independently reachable.
+
+**Testing.** Apply an unsupported/blank resolution → it auto-reverts after the timeout without
+confirmation; confirm within the window → it sticks; verify revert restores the prior arrangement
+exactly; verify confirmability when the target display is unreadable.
+
+---
+
+## Not yet converted (rest of Tier 1 — say the word and I'll write these next)
+
+DDC power's siblings **DDC auto-config** (parse capabilities string) · **EDID export** (raw
+`IODisplayEDID` blob read + file export — currently only EDID-*derived* fields are read) · **favorite
+resolutions** (pin/recall on top of `availableModes`) · **expand keyboard shortcuts** (the
+`GlobalHotKey` Carbon class is reusable — generalize beyond the single Reconnect-All binding) ·
+**native-looking OSD** + **notch-app integration API** · **networked TV/AVR control** (LG/Samsung/
+Philips/Yamaha — the largest self-contained greenfield chunk) · **Night Shift for TVs**.

--- a/Docs/block-live-display.sh
+++ b/Docs/block-live-display.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard for unattended OpenDisplay runs.
+# Blocks shell commands that would mutate REAL display state on this host
+# (the same Mac the agent is running on). Logic must be verified via `make test`
+# against the SimulatorProvider, never by yanking a live display.
+#
+# Hook contract: receives the tool-call JSON on stdin. Exit 2 = block the call
+# (the stderr message is shown to Claude). Exit 0 = allow.
+# NOTE: exit-code-2-blocks is the current Claude Code convention — confirm it
+# against your installed version if you customize this.
+
+payload="$(cat)"
+
+if printf '%s' "$payload" | grep -Eiq \
+  'opendisplay[^"]*(disconnect|reconnect|recover|scene[[:space:]]+apply|black[-_]?out)|displayplacer|cscreen|CGConfigureDisplay|SLSConfigureDisplay'; then
+  echo "BLOCKED: refusing a real display-mutating command during an unattended run. \
+Verify this behavior via 'make test' (SimulatorProvider) and non-destructive --json reads instead. (SAFETY rule.)" >&2
+  exit 2
+fi
+
+exit 0

--- a/Docs/block-live-display.sh
+++ b/Docs/block-live-display.sh
@@ -11,8 +11,11 @@
 
 payload="$(cat)"
 
+# `ddc … (power|input|vcp)` is blocked too: DPMS power-off and input switching can blank a real
+# panel, and the raw `vcp` escape hatch can write any code (0xD6 power, 0x60 input) — so vcp is
+# blocked wholesale during unattended runs (over-blocking reads is the safe direction for a guard).
 if printf '%s' "$payload" | grep -Eiq \
-  'opendisplay[^"]*(disconnect|reconnect|recover|scene[[:space:]]+apply|black[-_]?out)|displayplacer|cscreen|CGConfigureDisplay|SLSConfigureDisplay'; then
+  'opendisplay[^"]*(disconnect|reconnect|recover|scene[[:space:]]+apply|black[-_]?out|ddc[^"]*[[:space:]](power|input|vcp))|displayplacer|cscreen|CGConfigureDisplay|SLSConfigureDisplay'; then
   echo "BLOCKED: refusing a real display-mutating command during an unattended run. \
 Verify this behavior via 'make test' (SimulatorProvider) and non-destructive --json reads instead. (SAFETY rule.)" >&2
   exit 2


### PR DESCRIPTION
## What changed

Commits the six working documents that drove the 0.1.0 → 0.3.0 feature batches, previously untracked on the dev branches:

- **`OpenDisplay-Feature-Parity-Map.md`** — the BetterDisplay v4.x feature inventory mapped against OpenDisplay (Have / Partial / Gap), used as the roadmap's planning source of truth for the tier system.
- **`OpenDisplay-Issues-Batch-1.md`** — the six Batch-1 issue specs with acceptance criteria (Batches 2 and 3 specs are already committed; this completes the set).
- **`OpenDisplay-Audit-Brief-for-tooling.md`** — the brief for the code audit that corrected the parity map from inferred to ground-truth status.
- **`OpenDisplay-tooling-Autonomy-Playbook.md`** + **`AUTONOMOUS_PROMPT.md`** — how the autonomous build sessions were structured, scoped, and safety-gated.
- **`block-live-display.sh`** — the PreToolUse guard that blocks display-mutating shell commands during unattended runs (logic is verified against SimulatorProvider only).

## Why

Same rationale as the already-committed `PROGRESS.md`, `HANDOVER.md`, and Batch-2/3 specs: these document how the feature work was scoped, prioritized, and verified. The parity map in particular is referenced by the roadmap and is the canonical list of remaining Tier-1/2 gaps.

## Notes for review

Docs only — no code changes. Scanned for secrets/personal data before committing (clean). The parity map's BetterDisplay feature list is compiled from public sources (README, feature-matrix wiki), cited inline.
