### PR TITLE
Route volume media keys to the default audio output device

### DIFF
--- a/Apps/OpenDisplay/Sources/AppModel.swift
+++ b/Apps/OpenDisplay/Sources/AppModel.swift
@@ -383,6 +383,14 @@ final class AppModel: ObservableObject {
         if let alias = records[observation.recordID]?.alias, !alias.isEmpty {
             return alias
         }
+        return osDisplayName(for: observation)
+    }
+
+    /// The OS-provided display name (the monitor's product name), ignoring any user alias. Used for
+    /// audio-device→display matching: a CoreAudio HDMI/DP output carries the product name, never the
+    /// user's OpenDisplay alias, so matching an aliased display ("Desk") against "Dell U2720Q" must go
+    /// through this rather than `displayName(for:)`.
+    private func osDisplayName(for observation: DisplayObservation) -> String {
         let screenNumberKey = NSDeviceDescriptionKey("NSScreenNumber")
         if let cgID = observation.cgDisplayID,
            let screen = NSScreen.screens.first(where: {
@@ -1977,11 +1985,13 @@ final class AppModel: ObservableObject {
 
     /// The display the system's default audio output is routing through, or nil when the sound isn't
     /// going to a display (built-in speakers, AirPods, USB DAC, aggregate) or can't be matched to one.
-    /// Reads CoreAudio at call time and resolves the device→display via the pure matcher, using the same
-    /// user-facing names shown elsewhere. Volume keys pass through unless this returns a real display.
+    /// Reads CoreAudio at call time and resolves the device→display via the pure matcher, using each
+    /// display's OS/hardware name. Volume keys pass through unless this returns a real display.
     private func audioOutputDisplayID() -> DisplayRecordID? {
         guard let output = AudioOutputInfo.currentDefaultOutput() else { return nil }
-        let names = Dictionary(uniqueKeysWithValues: displays.map { ($0.recordID, displayName(for: $0)) })
+        // Match on the hardware/OS name, not the alias — the CoreAudio device name carries the product
+        // name, so an aliased display would otherwise never match.
+        let names = Dictionary(uniqueKeysWithValues: displays.map { ($0.recordID, osDisplayName(for: $0)) })
         return AudioOutputDisplayMatcher.match(
             deviceName: output.name, transport: output.transport, displays: displays, names: names)
     }

--- a/Apps/OpenDisplay/Sources/AppModel.swift
+++ b/Apps/OpenDisplay/Sources/AppModel.swift
@@ -1935,9 +1935,13 @@ final class AppModel: ObservableObject {
     /// others (e.g. volume on the built-in) pass through to macOS.
     @discardableResult
     func handleMediaKey(_ action: MediaKeyAction, fineStep: Bool) -> Bool {
+        // Volume/mute follow the system's default audio output (resolved at keypress); brightness
+        // follows the configured target mode and ignores this.
+        let audioTarget = action.isVolume ? audioOutputDisplayID() : nil
         guard let target = MediaKeyTargetPolicy.target(
             for: action, in: displays, cursor: cursorInCGCoordinates(),
-            mode: settings.mediaKeyTargetMode, volumeCapable: volumeCapableDisplayIDs())
+            mode: settings.mediaKeyTargetMode, volumeCapable: volumeCapableDisplayIDs(),
+            audioTarget: audioTarget)
         else { return false }
         let id = target.recordID
 
@@ -1969,6 +1973,17 @@ final class AppModel: ObservableObject {
         Set(displays
             .filter { $0.displayClass != .builtIn && ddcSupports(HardwareControl.volume.vcp, for: $0) }
             .map(\.recordID))
+    }
+
+    /// The display the system's default audio output is routing through, or nil when the sound isn't
+    /// going to a display (built-in speakers, AirPods, USB DAC, aggregate) or can't be matched to one.
+    /// Reads CoreAudio at call time and resolves the device→display via the pure matcher, using the same
+    /// user-facing names shown elsewhere. Volume keys pass through unless this returns a real display.
+    private func audioOutputDisplayID() -> DisplayRecordID? {
+        guard let output = AudioOutputInfo.currentDefaultOutput() else { return nil }
+        let names = Dictionary(uniqueKeysWithValues: displays.map { ($0.recordID, displayName(for: $0)) })
+        return AudioOutputDisplayMatcher.match(
+            deviceName: output.name, transport: output.transport, displays: displays, names: names)
     }
 
     /// The pointer location in Core Graphics (top-left origin) coordinates, to match `observation.origin`

--- a/Apps/OpenDisplay/Sources/AudioOutputInfo.swift
+++ b/Apps/OpenDisplay/Sources/AudioOutputInfo.swift
@@ -1,0 +1,69 @@
+#if os(macOS)
+import CoreAudio
+import Foundation
+import TopologyCore
+
+/// Reads the system's current default audio output device from CoreAudio (media-key volume fix).
+///
+/// Volume keys must follow whatever the sound is *actually* playing on, not whichever display the
+/// brightness target mode picks. This queries the default output device at keypress time — plain
+/// single-property reads on `kAudioObjectSystemObject` that cost microseconds, so no listener or cache
+/// is needed. The raw name + transport are handed to the pure `AudioOutputDisplayMatcher` in the core,
+/// which decides whether they map to a DDC-capable monitor.
+enum AudioOutputInfo {
+    /// A snapshot of the default output device: its CoreAudio name and physical transport.
+    struct Snapshot {
+        let name: String
+        let transport: AudioOutputTransport
+    }
+
+    /// The current default output device, or nil if CoreAudio has none / the query fails.
+    static func currentDefaultOutput() -> Snapshot? {
+        guard let deviceID = defaultOutputDeviceID() else { return nil }
+        return Snapshot(name: deviceName(deviceID) ?? "", transport: transportType(deviceID))
+    }
+
+    private static func defaultOutputDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var deviceID = AudioDeviceID(0)
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID)
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    private static func deviceName(_ id: AudioDeviceID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var name: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = withUnsafeMutablePointer(to: &name) { pointer in
+            AudioObjectGetPropertyData(id, &address, 0, nil, &size, pointer)
+        }
+        guard status == noErr, let name else { return nil }
+        return name.takeRetainedValue() as String
+    }
+
+    private static func transportType(_ id: AudioDeviceID) -> AudioOutputTransport {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var transport = UInt32(0)
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &transport)
+        guard status == noErr else { return .other }
+        switch transport {
+        case kAudioDeviceTransportTypeHDMI: return .hdmi
+        case kAudioDeviceTransportTypeDisplayPort: return .displayPort
+        default: return .other
+        }
+    }
+}
+#endif

--- a/Apps/OpenDisplay/Sources/SettingsView.swift
+++ b/Apps/OpenDisplay/Sources/SettingsView.swift
@@ -323,20 +323,24 @@ private struct HealthSection: View {
                 )) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Use the brightness & volume keys to control displays")
-                        Text("Routes the hardware F1/F2 brightness and volume keys to the chosen display "
-                             + "(external brightness/volume over DDC). Needs macOS Accessibility permission "
-                             + "to capture the keys; nothing is requested until you turn this on.")
+                        Text("Routes the hardware brightness keys to the chosen display (external "
+                             + "brightness over DDC). Volume keys follow the current sound output device, "
+                             + "driving that monitor's volume over DDC only when the audio plays through "
+                             + "it. Needs macOS Accessibility permission to capture the keys; nothing is "
+                             + "requested until you turn this on.")
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }
                 if model.settings.mediaKeyInterceptionEnabled {
-                    Picker("Control the", selection: Binding(
+                    Picker("Brightness keys control the", selection: Binding(
                         get: { model.settings.mediaKeyTargetMode }, set: { model.setMediaKeyTargetMode($0) })) {
                         Text("Display under the pointer").tag(MediaKeyTargetMode.underCursor)
                         Text("Main display").tag(MediaKeyTargetMode.mainDisplay)
                         Text("Built-in display").tag(MediaKeyTargetMode.builtInAlways)
                     }
                     .fixedSize()
+                    Text("Volume keys follow the current sound output device.")
+                        .font(.caption).foregroundStyle(.secondary)
                     if !MediaKeyTap.isAccessibilityTrusted {
                         HStack(spacing: 8) {
                             Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)

--- a/Packages/TopologyCore/Sources/TopologyCore/AudioOutputMatch.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/AudioOutputMatch.swift
@@ -41,10 +41,12 @@ public enum AudioOutputDisplayMatcher {
 
         let needle = normalize(deviceName)
         if !needle.isEmpty {
-            // Exact name match wins outright.
-            if let exact = candidates.first(where: { normalize(names[$0.recordID] ?? "") == needle }) {
-                return exact.recordID
-            }
+            // Exact name match — but only when a single display carries that name. Identical monitors
+            // share a product name, so two exact hits are ambiguous (CoreAudio routes to just one of
+            // them and we can't tell which) → don't guess.
+            let exact = candidates.filter { normalize(names[$0.recordID] ?? "") == needle }
+            if exact.count == 1 { return exact[0].recordID }
+            if exact.count > 1 { return nil }
             // Then prefix/contains either way — monitor audio device names usually equal or contain the
             // display's product name (and vice versa). One unambiguous hit only; two → don't guess.
             let contained = candidates.filter { candidate in

--- a/Packages/TopologyCore/Sources/TopologyCore/AudioOutputMatch.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/AudioOutputMatch.swift
@@ -1,0 +1,67 @@
+import DisplayDomain
+import Foundation
+
+/// The physical route a CoreAudio output device sits on. Only `hdmi`/`displayPort` can be a monitor's
+/// own audio; everything else (built-in speakers, USB DACs, Bluetooth/AirPods, aggregate/multi-output)
+/// is `other`. Held as plain values so the cross-platform core needn't import CoreAudio — the macOS
+/// glue maps `kAudioDeviceTransportType*` onto this (mirrors how `NXKeyType` keeps IOKit constants out
+/// of the core).
+public enum AudioOutputTransport: String, Hashable, Sendable {
+    case hdmi
+    case displayPort
+    case other
+}
+
+/// Resolves which display, if any, carries the system's default audio output (Batch-3, media-key fix).
+/// Pure: given the default output device's name + transport and the current displays (with their
+/// user-facing names), it returns the record of the external display the audio is coming through — or
+/// nil when the route isn't a display or can't be matched confidently. The volume media keys follow
+/// this so they drive the DDC volume of whatever the *sound* is actually playing on, not whatever
+/// display the brightness target mode happens to pick.
+public enum AudioOutputDisplayMatcher {
+    /// - Parameters:
+    ///   - deviceName: the default output device's CoreAudio name (e.g. the monitor's product name).
+    ///   - transport: the device's transport; anything but `hdmi`/`displayPort` yields nil (pass through).
+    ///   - displays: the current observations.
+    ///   - names: user-facing name per display (from the app's `displayName(for:)` resolution).
+    /// - Returns: the display the audio routes through, or nil to fail safe (never guess).
+    public static func match(
+        deviceName: String,
+        transport: AudioOutputTransport,
+        displays: [DisplayObservation],
+        names: [DisplayRecordID: String]
+    ) -> DisplayRecordID? {
+        // Only monitor audio (HDMI / DisplayPort) can belong to a display. Speakers, USB, AirPods,
+        // aggregate devices, etc. are never a display → pass through so macOS adjusts them natively.
+        guard transport == .hdmi || transport == .displayPort else { return nil }
+
+        // Audio can only be coming through an active, non-built-in panel.
+        let candidates = displays.filter { $0.isActive && $0.displayClass != .builtIn }
+        guard !candidates.isEmpty else { return nil }
+
+        let needle = normalize(deviceName)
+        if !needle.isEmpty {
+            // Exact name match wins outright.
+            if let exact = candidates.first(where: { normalize(names[$0.recordID] ?? "") == needle }) {
+                return exact.recordID
+            }
+            // Then prefix/contains either way — monitor audio device names usually equal or contain the
+            // display's product name (and vice versa). One unambiguous hit only; two → don't guess.
+            let contained = candidates.filter { candidate in
+                let hay = normalize(names[candidate.recordID] ?? "")
+                guard !hay.isEmpty else { return false }
+                return hay.contains(needle) || needle.contains(hay)
+            }
+            if contained.count == 1 { return contained[0].recordID }
+            if contained.count > 1 { return nil }
+        }
+
+        // No name match, but if exactly one external display exists the HDMI/DP audio must be coming
+        // through it. Two or more → ambiguous, so pass through (fail safe).
+        return candidates.count == 1 ? candidates[0].recordID : nil
+    }
+
+    private static func normalize(_ string: String) -> String {
+        string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Packages/TopologyCore/Sources/TopologyCore/MediaKey.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/MediaKey.swift
@@ -24,7 +24,10 @@ public enum MediaKeyAction: String, Hashable, Sendable, CaseIterable {
         }
     }
 
-    /// True for the volume/mute keys (which route over DDC audio, VCP `0x62`, on capable externals).
+    /// True for the volume/mute keys. Unlike brightness (which follows `MediaKeyTargetMode`), these
+    /// route to whichever display carries the system's *default audio output* — driving that monitor's
+    /// DDC volume (VCP `0x62`) only when the sound is actually coming out of it, and otherwise passing
+    /// through so macOS adjusts the real output device (speakers, AirPods, USB DAC) with its own HUD.
     public var isVolume: Bool {
         switch self {
         case .volumeUp, .volumeDown, .muteToggle: return true
@@ -77,40 +80,45 @@ public enum MediaKeyTargetMode: String, Hashable, Sendable, Codable, CaseIterabl
     case builtInAlways
 }
 
-/// Chooses the display a media key should drive (Batch-3 #1). Pure: given the displays, the cursor,
-/// the target mode, and which displays can take DDC volume, it returns the target observation — or
-/// nil to let the key pass through to macOS (e.g. a volume key with no DDC-audio-capable target, so
-/// the built-in's volume keys behave normally).
+/// Chooses the display a media key should drive (Batch-3 #1). Pure.
+///
+/// Brightness keys follow `mode` (under cursor / main / built-in). Volume/mute keys IGNORE `mode` and
+/// the cursor entirely: they route to `audioTarget` — the display carrying the system's default audio
+/// output — so the keys drive the DDC volume of whatever the sound is actually playing on. Returns nil
+/// to let the key pass through to macOS: for brightness when there's no active display, for volume when
+/// the audio route isn't a display, isn't active, or isn't DDC-volume-capable.
 public enum MediaKeyTargetPolicy {
     public static func target(
         for action: MediaKeyAction,
         in displays: [DisplayObservation],
         cursor: DisplayOrigin?,
         mode: MediaKeyTargetMode,
-        volumeCapable: Set<DisplayRecordID>
+        volumeCapable: Set<DisplayRecordID>,
+        audioTarget: DisplayRecordID?
     ) -> DisplayObservation? {
         let active = displays.filter { $0.isActive }
         guard !active.isEmpty else { return nil }
 
-        let base: DisplayObservation?
-        switch mode {
-        case .underCursor:
-            base = cursor.flatMap { point in active.first { contains($0, point) } }
-                ?? active.first { $0.isMain } ?? active.first
-        case .mainDisplay:
-            base = active.first { $0.isMain } ?? active.first
-        case .builtInAlways:
-            base = active.first { $0.displayClass == .builtIn }
-                ?? active.first { $0.isMain } ?? active.first
+        if action.isVolume {
+            // Volume follows the default audio output device, not the brightness target mode. Drive the
+            // monitor's DDC volume only when the audio routes through an active, DDC-volume-capable
+            // display; otherwise nil so the tap lets the key fall through to the real output device.
+            guard let audioTarget, volumeCapable.contains(audioTarget),
+                  let target = active.first(where: { $0.recordID == audioTarget })
+            else { return nil }
+            return target
         }
 
-        if action.isVolume {
-            // Volume/mute only make sense on a display that reports DDC audio; otherwise return nil so
-            // the tap lets the key fall through to system volume.
-            guard let base, volumeCapable.contains(base.recordID) else { return nil }
-            return base
+        switch mode {
+        case .underCursor:
+            return cursor.flatMap { point in active.first { contains($0, point) } }
+                ?? active.first { $0.isMain } ?? active.first
+        case .mainDisplay:
+            return active.first { $0.isMain } ?? active.first
+        case .builtInAlways:
+            return active.first { $0.displayClass == .builtIn }
+                ?? active.first { $0.isMain } ?? active.first
         }
-        return base
     }
 
     /// True if global point `p` lies within `display`'s bounds (origin + point size).

--- a/Packages/TopologyCore/Tests/TopologyCoreTests/AudioOutputMatchTests.swift
+++ b/Packages/TopologyCore/Tests/TopologyCoreTests/AudioOutputMatchTests.swift
@@ -71,6 +71,17 @@ final class AudioOutputMatchTests: XCTestCase {
             "two externals with no name match → don't guess")
     }
 
+    func testTwoExternalsSameExactNameIsAmbiguousNil() {
+        // Identical monitors share a product name; CoreAudio routes to only one → can't tell which.
+        let a = obs("a")
+        let b = obs("b")
+        XCTAssertNil(AudioOutputDisplayMatcher.match(
+            deviceName: "Dell U2720Q", transport: .hdmi,
+            displays: [a, b],
+            names: [rid("a"): "Dell U2720Q", rid("b"): "Dell U2720Q"]),
+            "two exact name matches → ambiguous, pass through")
+    }
+
     func testTwoExternalsAmbiguousNameMatchIsNil() {
         // Both display names contain the device name → ambiguous.
         let a = obs("a")

--- a/Packages/TopologyCore/Tests/TopologyCoreTests/AudioOutputMatchTests.swift
+++ b/Packages/TopologyCore/Tests/TopologyCoreTests/AudioOutputMatchTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import DisplayDomain
+@testable import TopologyCore
+
+final class AudioOutputMatchTests: XCTestCase {
+    private func obs(_ id: String, active: Bool = true, builtIn: Bool = false) -> DisplayObservation {
+        DisplayObservation(
+            recordID: DisplayRecordID(rawValue: id),
+            isActive: active,
+            displayClass: builtIn ? .builtIn : .external,
+            generation: .initial
+        )
+    }
+
+    private func rid(_ id: String) -> DisplayRecordID { DisplayRecordID(rawValue: id) }
+
+    func testExactNameMatchCaseInsensitive() {
+        let ext = obs("ext")
+        let match = AudioOutputDisplayMatcher.match(
+            deviceName: "dell u2720q", transport: .hdmi,
+            displays: [obs("builtin", builtIn: true), ext],
+            names: [rid("ext"): "Dell U2720Q", rid("builtin"): "Built-in Display"])
+        XCTAssertEqual(match, rid("ext"))
+    }
+
+    func testPrefixContainsMatch() {
+        // Audio device name contains the display's product name.
+        let ext = obs("ext")
+        let match = AudioOutputDisplayMatcher.match(
+            deviceName: "LG UltraFine Display Audio", transport: .displayPort,
+            displays: [ext], names: [rid("ext"): "LG UltraFine"])
+        XCTAssertEqual(match, rid("ext"))
+    }
+
+    func testDisplayNameContainsDeviceName() {
+        // Display name is the longer of the two.
+        let ext = obs("ext")
+        let match = AudioOutputDisplayMatcher.match(
+            deviceName: "Studio Display", transport: .hdmi,
+            displays: [ext], names: [rid("ext"): "Apple Studio Display (Main)"])
+        XCTAssertEqual(match, rid("ext"))
+    }
+
+    func testWrongTransportIsNil() {
+        let ext = obs("ext")
+        for transport in [AudioOutputTransport.other] {
+            XCTAssertNil(AudioOutputDisplayMatcher.match(
+                deviceName: "Dell U2720Q", transport: transport,
+                displays: [ext], names: [rid("ext"): "Dell U2720Q"]),
+                "non-HDMI/DP transport must never match a display")
+        }
+    }
+
+    func testSingleExternalFallbackWhenNoNameMatch() {
+        // Name doesn't match, but there's exactly one external → HDMI audio must be coming through it.
+        let ext = obs("ext")
+        let match = AudioOutputDisplayMatcher.match(
+            deviceName: "HDMI", transport: .hdmi,
+            displays: [obs("builtin", builtIn: true), ext],
+            names: [rid("ext"): "Some Monitor", rid("builtin"): "Built-in Display"])
+        XCTAssertEqual(match, rid("ext"))
+    }
+
+    func testTwoExternalsNoNameMatchIsAmbiguousNil() {
+        let a = obs("a")
+        let b = obs("b")
+        XCTAssertNil(AudioOutputDisplayMatcher.match(
+            deviceName: "HDMI Audio", transport: .hdmi,
+            displays: [a, b],
+            names: [rid("a"): "Monitor A", rid("b"): "Monitor B"]),
+            "two externals with no name match → don't guess")
+    }
+
+    func testTwoExternalsAmbiguousNameMatchIsNil() {
+        // Both display names contain the device name → ambiguous.
+        let a = obs("a")
+        let b = obs("b")
+        XCTAssertNil(AudioOutputDisplayMatcher.match(
+            deviceName: "Dell", transport: .displayPort,
+            displays: [a, b],
+            names: [rid("a"): "Dell U2720Q", rid("b"): "Dell P2419H"]),
+            "two name matches → ambiguous, pass through")
+    }
+
+    func testNameMatchWinsWhenSecondExternalDoesNotMatch() {
+        let a = obs("a")
+        let b = obs("b")
+        let match = AudioOutputDisplayMatcher.match(
+            deviceName: "Dell U2720Q", transport: .hdmi,
+            displays: [a, b],
+            names: [rid("a"): "Dell U2720Q", rid("b"): "LG UltraFine"])
+        XCTAssertEqual(match, rid("a"))
+    }
+
+    func testNoExternalDisplaysIsNil() {
+        XCTAssertNil(AudioOutputDisplayMatcher.match(
+            deviceName: "HDMI", transport: .hdmi,
+            displays: [obs("builtin", builtIn: true)],
+            names: [rid("builtin"): "Built-in Display"]))
+    }
+
+    func testInactiveExternalIsNotACandidate() {
+        // The only external is inactive → no candidate, even with a matching name.
+        let ext = obs("ext", active: false)
+        XCTAssertNil(AudioOutputDisplayMatcher.match(
+            deviceName: "Dell U2720Q", transport: .hdmi,
+            displays: [ext], names: [rid("ext"): "Dell U2720Q"]))
+    }
+
+    func testEmptyDeviceNameFallsBackToSingleExternal() {
+        let ext = obs("ext")
+        let match = AudioOutputDisplayMatcher.match(
+            deviceName: "", transport: .displayPort,
+            displays: [ext], names: [rid("ext"): "Dell U2720Q"])
+        XCTAssertEqual(match, rid("ext"))
+    }
+}

--- a/Packages/TopologyCore/Tests/TopologyCoreTests/MediaKeyTargetPolicyTests.swift
+++ b/Packages/TopologyCore/Tests/TopologyCoreTests/MediaKeyTargetPolicyTests.swift
@@ -19,12 +19,16 @@ final class MediaKeyTargetPolicyTests: XCTestCase {
         )
     }
 
+    private func rid(_ id: String) -> DisplayRecordID { DisplayRecordID(rawValue: id) }
+
+    // MARK: - Brightness (follows the target mode; unaffected by audio routing)
+
     func testUnderCursorPicksDisplayContainingPoint() {
         let builtIn = obs("builtin", main: true, builtIn: true, x: 0, y: 0)
         let ext = obs("ext", x: 1920, y: 0)
         let target = MediaKeyTargetPolicy.target(
             for: .brightnessUp, in: [builtIn, ext],
-            cursor: DisplayOrigin(x: 2000, y: 100), mode: .underCursor, volumeCapable: [])
+            cursor: DisplayOrigin(x: 2000, y: 100), mode: .underCursor, volumeCapable: [], audioTarget: nil)
         XCTAssertEqual(target?.recordID.rawValue, "ext")
     }
 
@@ -33,7 +37,7 @@ final class MediaKeyTargetPolicyTests: XCTestCase {
         let ext = obs("ext", x: 1920, y: 0)
         let target = MediaKeyTargetPolicy.target(
             for: .brightnessUp, in: [builtIn, ext],
-            cursor: DisplayOrigin(x: 99999, y: 99999), mode: .underCursor, volumeCapable: [])
+            cursor: DisplayOrigin(x: 99999, y: 99999), mode: .underCursor, volumeCapable: [], audioTarget: nil)
         XCTAssertEqual(target?.recordID.rawValue, "builtin")
     }
 
@@ -42,7 +46,7 @@ final class MediaKeyTargetPolicyTests: XCTestCase {
         let ext = obs("ext", main: true, x: 1920, y: 0)
         let target = MediaKeyTargetPolicy.target(
             for: .brightnessDown, in: [builtIn, ext],
-            cursor: DisplayOrigin(x: 100, y: 100), mode: .mainDisplay, volumeCapable: [])
+            cursor: DisplayOrigin(x: 100, y: 100), mode: .mainDisplay, volumeCapable: [], audioTarget: nil)
         XCTAssertEqual(target?.recordID.rawValue, "ext")
     }
 
@@ -51,37 +55,71 @@ final class MediaKeyTargetPolicyTests: XCTestCase {
         let ext = obs("ext", main: true, x: 1920, y: 0)
         let target = MediaKeyTargetPolicy.target(
             for: .brightnessUp, in: [builtIn, ext],
-            cursor: DisplayOrigin(x: 2000, y: 100), mode: .builtInAlways, volumeCapable: [])
+            cursor: DisplayOrigin(x: 2000, y: 100), mode: .builtInAlways, volumeCapable: [], audioTarget: nil)
         XCTAssertEqual(target?.recordID.rawValue, "builtin")
     }
 
     func testSingleDisplayResolvesToItself() {
         let only = obs("only", main: true, builtIn: true)
         let target = MediaKeyTargetPolicy.target(
-            for: .brightnessUp, in: [only], cursor: nil, mode: .underCursor, volumeCapable: [])
+            for: .brightnessUp, in: [only], cursor: nil, mode: .underCursor, volumeCapable: [], audioTarget: nil)
         XCTAssertEqual(target?.recordID.rawValue, "only")
     }
 
-    func testVolumeRoutesOnlyToDDCCapableDisplay() {
-        let ext = obs("ext", main: true)
-        let capable = MediaKeyTargetPolicy.target(
-            for: .volumeUp, in: [ext], cursor: nil, mode: .mainDisplay,
-            volumeCapable: [DisplayRecordID(rawValue: "ext")])
-        XCTAssertEqual(capable?.recordID.rawValue, "ext")
+    // MARK: - Volume (follows the default-audio display, ignoring mode/cursor)
+
+    func testVolumeRoutesToAudioTargetRegardlessOfMode() {
+        // Cursor + main are on the built-in, but audio plays through the external → drive the external.
+        let builtIn = obs("builtin", main: true, builtIn: true, x: 0, y: 0)
+        let ext = obs("ext", x: 1920, y: 0)
+        let target = MediaKeyTargetPolicy.target(
+            for: .volumeUp, in: [builtIn, ext],
+            cursor: DisplayOrigin(x: 100, y: 100), mode: .builtInAlways,
+            volumeCapable: [rid("ext")], audioTarget: rid("ext"))
+        XCTAssertEqual(target?.recordID.rawValue, "ext")
     }
 
-    func testVolumeOnNonCapableTargetPassesThrough() {
-        let builtIn = obs("builtin", main: true, builtIn: true)
+    func testVolumeIgnoresMainWhenAudioIsElsewhere() {
+        let mainExt = obs("main-ext", main: true, x: 0, y: 0)
+        let audioExt = obs("audio-ext", x: 1920, y: 0)
         let target = MediaKeyTargetPolicy.target(
-            for: .volumeUp, in: [builtIn], cursor: nil, mode: .mainDisplay, volumeCapable: [])
-        XCTAssertNil(target, "volume key with no DDC-audio-capable target should pass through (nil)")
+            for: .volumeDown, in: [mainExt, audioExt],
+            cursor: DisplayOrigin(x: 50, y: 50), mode: .mainDisplay,
+            volumeCapable: [rid("main-ext"), rid("audio-ext")], audioTarget: rid("audio-ext"))
+        XCTAssertEqual(target?.recordID.rawValue, "audio-ext")
+    }
+
+    func testVolumePassesThroughWhenNoAudioTarget() {
+        // Default output is not a display (e.g. speakers/AirPods) → nil, let macOS handle it.
+        let ext = obs("ext", main: true)
+        let target = MediaKeyTargetPolicy.target(
+            for: .volumeUp, in: [ext], cursor: nil, mode: .mainDisplay,
+            volumeCapable: [rid("ext")], audioTarget: nil)
+        XCTAssertNil(target)
+    }
+
+    func testVolumePassesThroughWhenAudioTargetNotVolumeCapable() {
+        let ext = obs("ext", main: true)
+        let target = MediaKeyTargetPolicy.target(
+            for: .volumeUp, in: [ext], cursor: nil, mode: .mainDisplay,
+            volumeCapable: [], audioTarget: rid("ext"))
+        XCTAssertNil(target, "audio display that can't take DDC volume should pass through")
+    }
+
+    func testVolumePassesThroughWhenAudioTargetInactive() {
+        let ext = obs("ext", active: false)
+        let other = obs("other", main: true)
+        let target = MediaKeyTargetPolicy.target(
+            for: .muteToggle, in: [ext, other], cursor: nil, mode: .mainDisplay,
+            volumeCapable: [rid("ext")], audioTarget: rid("ext"))
+        XCTAssertNil(target, "audio display that is inactive should pass through")
     }
 
     func testInactiveAndEmptyYieldNil() {
         XCTAssertNil(MediaKeyTargetPolicy.target(
-            for: .brightnessUp, in: [], cursor: nil, mode: .mainDisplay, volumeCapable: []))
+            for: .brightnessUp, in: [], cursor: nil, mode: .mainDisplay, volumeCapable: [], audioTarget: nil))
         let off = obs("off", active: false)
         XCTAssertNil(MediaKeyTargetPolicy.target(
-            for: .brightnessUp, in: [off], cursor: nil, mode: .mainDisplay, volumeCapable: []))
+            for: .brightnessUp, in: [off], cursor: nil, mode: .mainDisplay, volumeCapable: [], audioTarget: nil))
     }
 }


### PR DESCRIPTION
## Problem

The media-key interception (Settings → "Use the brightness & volume keys to control displays") routed the hardware volume/mute keys to whichever display the brightness **target mode** resolved (under cursor / main / built-in). If that display was a DDC-audio-capable external, the keys changed the **monitor's** DDC volume even when system sound was playing through the MacBook speakers, AirPods, a USB DAC, etc.

Real scenario: built-in display off, external monitor is main, default audio output = MacBook speakers → volume keys wrongly drove the monitor's DDC volume while sound kept coming from the speakers.

## Fix

Volume/mute keys now follow the **system default audio output device**, decoupled from the brightness target mode:

- **Not a display** (built-in speakers, headphones, AirPods, USB DAC, aggregate/multi-output) → **pass through** so macOS adjusts that device natively with its own HUD.
- **An external monitor's HDMI/DP audio**, active and DDC-volume-capable → drive **that** monitor's DDC volume/mute, even if the cursor/main display is elsewhere.
- Inactive, not DDC-volume-capable, or unmatchable device → **pass through** (fail safe, never guess).

**Brightness keys are unchanged** — they still follow `MediaKeyTargetMode`.

## Implementation (pure-core / macOS-glue split)

- **`AudioOutputInfo.swift`** (new, macOS glue) — reads the CoreAudio default output device name + transport type per keypress (single property reads, microseconds; no listener/cache).
- **`AudioOutputMatch.swift`** (new, pure TopologyCore, no CoreAudio/IOKit) — `AudioOutputTransport` enum + `AudioOutputDisplayMatcher`: transport must be hdmi/displayPort else nil; case-insensitive exact→contains name match to a display; single-active-external fallback; ambiguous → nil.
- **`MediaKey.swift`** — `MediaKeyTargetPolicy.target` gains an `audioTarget:` parameter; the volume branch ignores mode/cursor and routes only to that display when it's active + volume-capable. Updated doc comments on the policy and `isVolume`.
- **`AppModel.swift`** — `handleMediaKey` resolves `audioTarget` (via new `audioOutputDisplayID()`, reusing `displayName(for:)`) for volume actions only; mute's `preMuteVolume` logic and `volumeCapableDisplayIDs()` fail-open behavior unchanged.
- **`SettingsView.swift`** — picker relabeled "Brightness keys control the…", added "Volume keys follow the current sound output device." No new user setting.

## Tests / verification

- `make test` green — added 12 matcher tests (name exact/prefix/case-insensitive, wrong transport, single-external fallback, two-external ambiguity); migrated policy tests to the new signature (volume routes to `audioTarget` regardless of mode; passes through when nil/inactive/not-capable; brightness unchanged).
- Both `OpenDisplay` and `OpenDisplay-PublicAPIOnly` schemes build (ran `make xcode` — two new source files).

### Manual live checks
1. Sound output = MacBook speakers, cursor/main on external → volume keys change **speaker** volume with the **native macOS HUD**.
2. Sound output = the monitor (HDMI/DP) → volume keys change **monitor DDC** volume with **OpenDisplay's OSD**.
3. Brightness keys still follow the configured target mode in both cases.
