### PR TITLE
Add in-app update check

### DIFF
--- a/Apps/OpenDisplay/Sources/AppModel.swift
+++ b/Apps/OpenDisplay/Sources/AppModel.swift
@@ -233,6 +233,15 @@ final class AppModel: ObservableObject {
     @Published private(set) var favorites = FavoriteResolutions()
     private let favoritesStore: FavoritesStore?
 
+    /// Update-check state driving the menu's "Check for updates" row.
+    enum UpdateState: Equatable {
+        case idle
+        case checking
+        case upToDate
+        case available(version: String, url: String)
+    }
+    @Published private(set) var updateState: UpdateState = .idle
+
     /// Live "Keep these settings?" prompt for an arrangement-altering change (Issue 6), or nil when no
     /// revert window is open. Drives the countdown banner; the UI calls `confirmArrangementChange()` /
     /// `revertArrangementChange()`.
@@ -304,6 +313,7 @@ final class AppModel: ObservableObject {
             reconcileAdaptiveLoop()  // start adaptive brightness/warmth if enabled for this topology
             #endif
             autoDisconnectPolicy.seed(externalPresent: hasExternalDisplay)  // don't treat a pre-attached external as an arrival
+            await autoCheckForUpdatesIfDue()
             await writeBaselineCheckpoint()
             if let marker = Self.readRotationMarker() {
                 // A prior experimental rotation didn't confirm — restore that display's safe angle and
@@ -1779,6 +1789,46 @@ final class AppModel: ObservableObject {
         settings.preventDisplaySleepWithExternal = enabled
         persistSettings()
         reconcileDisplaySleepGuard()
+    }
+
+    func setUpdateCheckEnabled(_ enabled: Bool) {
+        guard settings.updateCheckEnabled != enabled else { return }
+        settings.updateCheckEnabled = enabled
+        persistSettings()
+    }
+
+    private static let lastUpdateCheckKey = "OpenDisplayLastUpdateCheck"
+
+    /// Runs the daily background update check when the toggle is on and one is due. Failures stay
+    /// silent (`idle`) — a background check must never surface an error.
+    func autoCheckForUpdatesIfDue() async {
+        guard settings.updateCheckEnabled else { return }
+        let last = UserDefaults.standard.object(forKey: Self.lastUpdateCheckKey) as? Date
+        guard UpdateCheckPolicy.shouldAutoCheck(lastCheck: last, now: Date()) else { return }
+        await checkForUpdates()
+    }
+
+    /// Fetches the latest release and publishes the outcome. An unusable answer (offline,
+    /// rate-limited, bad tag) shows "up to date" only for a user-initiated re-check via the menu —
+    /// here it just returns to `idle`.
+    func checkForUpdates() async {
+        guard updateState != .checking else { return }
+        updateState = .checking
+        let availability = await UpdateChecker.fetchAvailability()
+        UserDefaults.standard.set(Date(), forKey: Self.lastUpdateCheckKey)
+        switch availability {
+        case .available(let version, let url): updateState = .available(version: version, url: url)
+        case .upToDate: updateState = .upToDate
+        case nil: updateState = .idle
+        }
+    }
+
+    /// Opens the newest release's page (menu action for the "Update available" row).
+    func openUpdatePage() {
+        let url: String
+        if case .available(_, let releaseURL) = updateState { url = releaseURL }
+        else { url = UpdateChecker.releasesPage }
+        if let target = URL(string: url) { NSWorkspace.shared.open(target) }
     }
 
     /// Acquire or release the keep-awake assertion for the current (toggle, external-presence) state.

--- a/Apps/OpenDisplay/Sources/MenuBarView.swift
+++ b/Apps/OpenDisplay/Sources/MenuBarView.swift
@@ -134,7 +134,27 @@ struct MenuBarView: View {
                           enabled: !model.busy) { Task { await model.reconnectAll() } }
             MenuActionRow(title: "Displays & arrangement…", systemImage: "rectangle.3.group",
                           showChevron: true) { showSettings() }
-            MenuActionRow(title: "Check for updates", systemImage: "arrow.down.circle", soon: true)
+            updatesRow
+        }
+    }
+
+    /// "Check for updates" reflects the checker's live state: idle → runs a check, checking →
+    /// disabled spinner text, up to date → confirmation (click re-checks), update available →
+    /// version badge and a click-through to the release page.
+    @ViewBuilder private var updatesRow: some View {
+        switch model.updateState {
+        case .idle:
+            MenuActionRow(title: "Check for updates", systemImage: "arrow.down.circle",
+                          showChevron: false) { Task { await model.checkForUpdates() } }
+        case .checking:
+            MenuActionRow(title: "Checking for updates…", systemImage: "arrow.down.circle",
+                          showChevron: false, enabled: false)
+        case .upToDate:
+            MenuActionRow(title: "Up to date", systemImage: "checkmark.circle",
+                          showChevron: false) { Task { await model.checkForUpdates() } }
+        case .available(let version, _):
+            MenuActionRow(title: "Update available", systemImage: "arrow.down.circle.fill",
+                          badge: version, showChevron: false) { model.openUpdatePage() }
         }
     }
 
@@ -328,6 +348,7 @@ private struct MenuActionRow: View {
     let title: String
     let systemImage: String
     var soon = false
+    var badge: String?
     var showChevron = true
     var enabled = true
     var action: () -> Void = {}
@@ -344,6 +365,8 @@ private struct MenuActionRow: View {
                 Spacer()
                 if soon {
                     ODBadge("Soon")
+                } else if let badge {
+                    ODBadge(badge, tone: .accent, solid: true)
                 } else if showChevron {
                     Image(systemName: "chevron.right").font(.system(size: 10)).foregroundStyle(.tertiary)
                 }

--- a/Apps/OpenDisplay/Sources/SettingsView.swift
+++ b/Apps/OpenDisplay/Sources/SettingsView.swift
@@ -267,6 +267,18 @@ private struct HealthSection: View {
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }
+                Toggle(isOn: Binding(
+                    get: { model.settings.updateCheckEnabled },
+                    set: { model.setUpdateCheckEnabled($0) }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Check for updates automatically")
+                        Text("Asks GitHub for the newest release at most once a day and shows it in the "
+                             + "menu. Nothing is downloaded or installed automatically, and the menu\u{2019}s "
+                             + "manual \u{201C}Check for updates\u{201D} works either way.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
 
                 Divider()
 

--- a/Apps/OpenDisplay/Sources/UpdateChecker.swift
+++ b/Apps/OpenDisplay/Sources/UpdateChecker.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TopologyCore
+
+/// Fetches the newest published release from GitHub and compares it against the running build.
+/// Decision logic (version compare, throttling) lives in `UpdateCheckPolicy` (TopologyCore, tested);
+/// this file is only the I/O: one anonymous GET to the public releases API, nothing downloaded,
+/// nothing sent beyond the request itself.
+enum UpdateChecker {
+    struct LatestRelease: Decodable {
+        let tagName: String
+        let htmlURL: String
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case htmlURL = "html_url"
+        }
+    }
+
+    static let releasesPage = "https://github.com/aquitaine/OpenDisplay/releases/latest"
+    private static let latestAPI = "https://api.github.com/repos/aquitaine/OpenDisplay/releases/latest"
+
+    /// The running build's marketing version ("0.4.1").
+    static var currentVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
+    }
+
+    /// Asks GitHub for the latest release and returns the comparison result, or nil when the network
+    /// or the tag is unusable — callers treat nil as "unknown", never as "update available".
+    static func fetchAvailability() async -> UpdateAvailability? {
+        guard let url = URL(string: latestAPI) else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200,
+              let release = try? JSONDecoder().decode(LatestRelease.self, from: data) else {
+            return nil
+        }
+        return UpdateCheckPolicy.availability(
+            current: currentVersion, latestTag: release.tagName, releaseURL: release.htmlURL)
+    }
+}

--- a/Packages/TopologyCore/Sources/TopologyCore/SettingsStore.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/SettingsStore.swift
@@ -70,6 +70,9 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
     /// Learned brightness offsets (user's manual tweak relative to the built-in), keyed by
     /// `DisplayRecordID.rawValue`; survives relaunch so sync resumes at the user's preference.
     public var adaptiveBrightnessOffsetByDisplay: [String: Float]
+    /// When on, ask GitHub for the newest release at most once a day and surface it in the menu.
+    /// Manual "Check for updates" works regardless. Nothing is ever downloaded automatically.
+    public var updateCheckEnabled: Bool
 
     public init(
         persistencePolicy: PersistencePolicy = .reconnectOnQuit,
@@ -95,7 +98,8 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         adaptiveFallbackNightLevel: Float = 0.35,
         adaptiveEveningPreset: Int = 4,
         adaptiveDayPresetByDisplay: [String: Int] = [:],
-        adaptiveBrightnessOffsetByDisplay: [String: Float] = [:]
+        adaptiveBrightnessOffsetByDisplay: [String: Float] = [:],
+        updateCheckEnabled: Bool = true
     ) {
         self.persistencePolicy = persistencePolicy
         self.confirmationCountdownSeconds = confirmationCountdownSeconds
@@ -121,6 +125,7 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         self.adaptiveEveningPreset = adaptiveEveningPreset
         self.adaptiveDayPresetByDisplay = adaptiveDayPresetByDisplay
         self.adaptiveBrightnessOffsetByDisplay = adaptiveBrightnessOffsetByDisplay
+        self.updateCheckEnabled = updateCheckEnabled
     }
 
     public static let `default` = OpenDisplaySettings()
@@ -148,6 +153,7 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         case adaptiveEveningPreset
         case adaptiveDayPresetByDisplay
         case adaptiveBrightnessOffsetByDisplay
+        case updateCheckEnabled
     }
 
     /// Tolerant decoder: every missing key falls back to its default and unknown keys are ignored,
@@ -221,6 +227,8 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         adaptiveBrightnessOffsetByDisplay = try container
             .decodeIfPresent([String: Float].self, forKey: .adaptiveBrightnessOffsetByDisplay)
             ?? defaults.adaptiveBrightnessOffsetByDisplay
+        updateCheckEnabled = try container.decodeIfPresent(Bool.self, forKey: .updateCheckEnabled)
+            ?? defaults.updateCheckEnabled
     }
 }
 

--- a/Packages/TopologyCore/Sources/TopologyCore/UpdateCheck.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/UpdateCheck.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A parsed `major.minor.patch` version. Tolerates a leading `v` and a trailing pre-release/build
+/// suffix (`0.5.0-beta.1` parses as 0.5.0); anything else non-numeric fails the parse so the caller
+/// can decline to compare rather than guess.
+public struct SemanticVersion: Hashable, Sendable, Comparable {
+    public let major: Int
+    public let minor: Int
+    public let patch: Int
+
+    public init?(_ string: String) {
+        var core = string.hasPrefix("v") || string.hasPrefix("V") ? String(string.dropFirst()) : string
+        if let cut = core.firstIndex(where: { $0 == "-" || $0 == "+" }) {
+            core = String(core[..<cut])
+        }
+        let parts = core.split(separator: ".", omittingEmptySubsequences: false)
+        guard (1...3).contains(parts.count) else { return nil }
+        var numbers: [Int] = []
+        for part in parts {
+            guard let n = Int(part), n >= 0 else { return nil }
+            numbers.append(n)
+        }
+        while numbers.count < 3 { numbers.append(0) }
+        major = numbers[0]
+        minor = numbers[1]
+        patch = numbers[2]
+    }
+
+    public static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+    }
+}
+
+/// Outcome of comparing the running version against the newest published release.
+public enum UpdateAvailability: Hashable, Sendable {
+    /// The running build is the latest (or newer — a dev build ahead of the last release).
+    case upToDate
+    /// A newer release exists; `version` is its display string, `url` its release page.
+    case available(version: String, url: String)
+}
+
+/// Pure decision logic for the update check — version comparison and auto-check throttling. The
+/// network fetch and persistence live app-side; everything here is deterministic and unit-tested.
+public enum UpdateCheckPolicy {
+    /// Compares the running version with the latest release tag. Returns nil when either side
+    /// doesn't parse — an unparseable tag must not produce an "update available" prompt.
+    public static func availability(
+        current: String, latestTag: String, releaseURL: String
+    ) -> UpdateAvailability? {
+        guard let current = SemanticVersion(current),
+              let latest = SemanticVersion(latestTag) else { return nil }
+        guard latest > current else { return .upToDate }
+        var display = latestTag
+        if display.hasPrefix("v") || display.hasPrefix("V") { display.removeFirst() }
+        return .available(version: display, url: releaseURL)
+    }
+
+    /// Whether a background (non-user-initiated) check is due. A never-checked install is due
+    /// immediately; afterwards at most once per `minimumInterval` (default 24h). A `lastCheck` in
+    /// the future (clock rolled back) counts as due rather than silencing checks indefinitely.
+    public static func shouldAutoCheck(
+        lastCheck: Date?, now: Date, minimumInterval: TimeInterval = 24 * 60 * 60
+    ) -> Bool {
+        guard let lastCheck else { return true }
+        if lastCheck > now { return true }
+        return now.timeIntervalSince(lastCheck) >= minimumInterval
+    }
+}

--- a/Packages/TopologyCore/Tests/TopologyCoreTests/UpdateCheckTests.swift
+++ b/Packages/TopologyCore/Tests/TopologyCoreTests/UpdateCheckTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import TopologyCore
+
+final class UpdateCheckTests: XCTestCase {
+    // MARK: - SemanticVersion parsing
+
+    func testParsesPlainVersion() {
+        let v = SemanticVersion("0.4.1")
+        XCTAssertEqual(v?.major, 0)
+        XCTAssertEqual(v?.minor, 4)
+        XCTAssertEqual(v?.patch, 1)
+    }
+
+    func testParsesLeadingV() {
+        XCTAssertEqual(SemanticVersion("v1.2.3"), SemanticVersion("1.2.3"))
+        XCTAssertEqual(SemanticVersion("V1.2.3"), SemanticVersion("1.2.3"))
+    }
+
+    func testMissingComponentsDefaultToZero() {
+        XCTAssertEqual(SemanticVersion("1"), SemanticVersion("1.0.0"))
+        XCTAssertEqual(SemanticVersion("1.2"), SemanticVersion("1.2.0"))
+    }
+
+    func testStripsPreReleaseAndBuildSuffix() {
+        XCTAssertEqual(SemanticVersion("0.5.0-beta.1"), SemanticVersion("0.5.0"))
+        XCTAssertEqual(SemanticVersion("0.5.0+42"), SemanticVersion("0.5.0"))
+    }
+
+    func testRejectsGarbage() {
+        XCTAssertNil(SemanticVersion(""))
+        XCTAssertNil(SemanticVersion("latest"))
+        XCTAssertNil(SemanticVersion("1.2.3.4"))
+        XCTAssertNil(SemanticVersion("1..3"))
+        XCTAssertNil(SemanticVersion("1.-2.3"))
+    }
+
+    func testOrdering() {
+        XCTAssertLessThan(SemanticVersion("0.4.1")!, SemanticVersion("0.5.0")!)
+        XCTAssertLessThan(SemanticVersion("0.9.9")!, SemanticVersion("1.0.0")!)
+        XCTAssertLessThan(SemanticVersion("1.0.0")!, SemanticVersion("1.0.1")!)
+        XCTAssertFalse(SemanticVersion("1.0.0")! < SemanticVersion("1.0.0")!)
+    }
+
+    // MARK: - Availability
+
+    func testNewerTagIsAvailable() {
+        let result = UpdateCheckPolicy.availability(
+            current: "0.4.1", latestTag: "v0.5.0", releaseURL: "https://example.com/r")
+        XCTAssertEqual(result, .available(version: "0.5.0", url: "https://example.com/r"))
+    }
+
+    func testSameVersionIsUpToDate() {
+        XCTAssertEqual(
+            UpdateCheckPolicy.availability(current: "0.4.1", latestTag: "v0.4.1", releaseURL: "u"),
+            .upToDate)
+    }
+
+    func testDevBuildAheadOfLatestReleaseIsUpToDate() {
+        XCTAssertEqual(
+            UpdateCheckPolicy.availability(current: "0.6.0", latestTag: "v0.5.0", releaseURL: "u"),
+            .upToDate)
+    }
+
+    func testUnparseableTagYieldsNoDecision() {
+        XCTAssertNil(UpdateCheckPolicy.availability(current: "0.4.1", latestTag: "latest", releaseURL: "u"))
+        XCTAssertNil(UpdateCheckPolicy.availability(current: "dev", latestTag: "v0.5.0", releaseURL: "u"))
+    }
+
+    // MARK: - Auto-check throttle
+
+    func testNeverCheckedIsDue() {
+        XCTAssertTrue(UpdateCheckPolicy.shouldAutoCheck(lastCheck: nil, now: Date()))
+    }
+
+    func testRecentCheckIsNotDue() {
+        let now = Date()
+        XCTAssertFalse(UpdateCheckPolicy.shouldAutoCheck(lastCheck: now.addingTimeInterval(-3600), now: now))
+    }
+
+    func testCheckOlderThanIntervalIsDue() {
+        let now = Date()
+        XCTAssertTrue(UpdateCheckPolicy.shouldAutoCheck(
+            lastCheck: now.addingTimeInterval(-25 * 3600), now: now))
+    }
+
+    func testFutureLastCheckIsDue() {
+        let now = Date()
+        XCTAssertTrue(UpdateCheckPolicy.shouldAutoCheck(lastCheck: now.addingTimeInterval(3600), now: now))
+    }
+
+    func testCustomInterval() {
+        let now = Date()
+        XCTAssertTrue(UpdateCheckPolicy.shouldAutoCheck(
+            lastCheck: now.addingTimeInterval(-120), now: now, minimumInterval: 60))
+        XCTAssertFalse(UpdateCheckPolicy.shouldAutoCheck(
+            lastCheck: now.addingTimeInterval(-30), now: now, minimumInterval: 60))
+    }
+}


### PR DESCRIPTION
Replaces the menu's "Check for updates — Soon" placeholder with a working updater.

- **TopologyCore (pure, +15 tests):** `SemanticVersion` (tolerant parse: `v` prefix, pre-release suffixes, garbage → nil) and `UpdateCheckPolicy` (compare + daily auto-check throttle; unparseable tags never produce an update prompt; future lastCheck counts as due).
- **App:** `UpdateChecker` does one anonymous GET to `releases/latest`; AppModel publishes the state; the menu row shows check → checking → up-to-date / version badge → release page. Launch auto-check at most once a day, default on, toggleable in Health & Recovery. Nothing auto-downloads.

301 tests green; both app schemes build.
