### PR TITLE
Add overlay and combined dimming methods

### DIFF
--- a/Apps/OpenDisplay/Sources/AppModel.swift
+++ b/Apps/OpenDisplay/Sources/AppModel.swift
@@ -228,6 +228,9 @@ final class AppModel: ObservableObject {
     /// Holds the "prevent display idle-sleep" power assertion while the toggle is on and an external
     /// display is present (Issue 3). Decision logic is the platform-independent `DisplaySleepGuard`.
     private let sleepGuard: DisplaySleepGuard
+    /// Black click-through overlay windows for the overlay/combined dimming methods. Process-bound —
+    /// every overlay disappears with the app, so quit teardown only has the gamma half to restore.
+    private let dimOverlay = DimOverlayController()
 
     /// Pinned favourite resolutions per display (Batch-2 #3), persisted to favorites.json.
     @Published private(set) var favorites = FavoriteResolutions()
@@ -544,11 +547,32 @@ final class AppModel: ObservableObject {
         await refresh()
     }
 
-    /// Sets a display's software (gamma) dim, 0.15...1 where 1 = no dim. Works on any display.
+    /// Sets a display's software dim, 1 (none) down toward 0, expressed through the configured
+    /// dimming method — gamma table, overlay window, or both. Works on any display.
     func setSoftwareDim(_ level: Float, for observation: DisplayObservation) {
         guard let cgID = observation.cgDisplayID else { return }
         softwareDim[observation.recordID] = level
-        observer.setGammaDim(level, for: cgID)
+        applyDim(level: level, cgID: cgID)
+    }
+
+    /// Expresses one dim level through the current method's gamma/overlay split.
+    private func applyDim(level: Float, cgID: CGDirectDisplayID) {
+        let split = DimmingComposer.split(method: settings.dimmingMethod, level: level)
+        observer.setGammaDim(split.gammaLevel, for: cgID)
+        dimOverlay.setAlpha(split.overlayAlpha, for: cgID)
+    }
+
+    /// Switches the dimming method and re-expresses every live dim through it, so the slider
+    /// positions keep meaning the same darkness. (A software-brightness fallback dim migrates too —
+    /// both layers read from the same per-display level.)
+    func setDimmingMethod(_ method: DimmingMethod) {
+        guard settings.dimmingMethod != method else { return }
+        settings.dimmingMethod = method
+        persistSettings()
+        for (id, level) in softwareDim where level < 1.0 && !blackedOut.contains(id) {
+            guard let cgID = displays.first(where: { $0.recordID == id })?.cgDisplayID else { continue }
+            applyDim(level: level, cgID: cgID)
+        }
     }
 
     /// Displays currently blacked out (gamma driven to zero — the panel stays logically connected so it
@@ -567,10 +591,11 @@ final class AppModel: ObservableObject {
         let id = observation.recordID
         if blackedOut.contains(id) {
             blackedOut.remove(id)
-            observer.setGammaDim(softwareDim[id] ?? 1.0, for: cgID)
+            applyDim(level: softwareDim[id] ?? 1.0, cgID: cgID)
         } else {
             blackedOut.insert(id)
             observer.setGammaDim(0.0, for: cgID)
+            dimOverlay.remove(for: cgID)  // gamma 0 is already fully black; restore recreates it
         }
     }
 
@@ -661,6 +686,7 @@ final class AppModel: ObservableObject {
         if !inputSource.keys.allSatisfy(ids.contains) { inputSource = inputSource.filter { ids.contains($0.key) } }
         if !colorProfileName.keys.allSatisfy(ids.contains) { colorProfileName = colorProfileName.filter { ids.contains($0.key) } }
         if !softwareDim.keys.allSatisfy(ids.contains) { softwareDim = softwareDim.filter { ids.contains($0.key) } }
+        dimOverlay.reconcile()  // drop overlays for departed displays, re-fit after mode/layout changes
         if !colorProfileControllable.keys.allSatisfy(ids.contains) { colorProfileControllable = colorProfileControllable.filter { ids.contains($0.key) } }
         if !blackedOut.allSatisfy(ids.contains) { blackedOut = blackedOut.filter(ids.contains) }
         #if !PUBLIC_API_ONLY
@@ -784,6 +810,7 @@ final class AppModel: ObservableObject {
                     // holds the panel at gamma 0 — a background refresh must not light it up.
                     if let dim = softwareDim[id], dim < 1.0, !blackedOut.contains(id) {
                         observer.setGammaDim(1.0, for: cgID)
+                        dimOverlay.remove(for: cgID)
                         softwareDim[id] = nil
                     }
                     brightness[id] = Float(reading.current) / Float(reading.max)
@@ -1093,7 +1120,7 @@ final class AppModel: ObservableObject {
     private func reapplySoftwareDim(for observation: DisplayObservation) {
         guard let cgID = observation.cgDisplayID, !blackedOut.contains(observation.recordID),
               let dim = softwareDim[observation.recordID], dim < 1.0 else { return }
-        observer.setGammaDim(dim, for: cgID)
+        applyDim(level: dim, cgID: cgID)
     }
 
     /// Current rotation of a display in degrees (0/90/180/270), read via public Core Graphics.
@@ -1913,6 +1940,7 @@ final class AppModel: ObservableObject {
         }
         CoreGraphicsProvider.restoreGamma()
         softwareDim.removeAll()
+        dimOverlay.removeAll()
         sleepGuard.releaseAll()
     }
 

--- a/Apps/OpenDisplay/Sources/DimOverlayController.swift
+++ b/Apps/OpenDisplay/Sources/DimOverlayController.swift
@@ -1,0 +1,73 @@
+import AppKit
+
+/// Owns the black, click-through overlay windows the overlay/combined dimming methods use — one per
+/// dimmed display. Windows are borderless, ignore the mouse, join every Space, sit just below the
+/// status bar (so the menu bar and this app's popover stay reachable at any dim level — the escape
+/// hatch is never dimmed away), and are excluded from screen capture so screenshots come out clean.
+/// All state is process-bound: every overlay vanishes the instant the app exits, so unlike a gamma
+/// dim there is nothing to restore on quit.
+@MainActor
+final class DimOverlayController {
+    private var windows: [CGDirectDisplayID: NSWindow] = [:]
+
+    /// Applies `alpha` (0...1, where 0 removes the overlay) to the display's overlay window,
+    /// creating it on first use. No-ops if the display has no NSScreen (offline / mid-reconfig).
+    func setAlpha(_ alpha: Float, for displayID: CGDirectDisplayID) {
+        guard alpha > 0.001 else {
+            remove(for: displayID)
+            return
+        }
+        guard let screen = Self.screen(for: displayID) else { return }
+        let window = windows[displayID] ?? makeWindow(on: screen)
+        windows[displayID] = window
+        window.setFrame(screen.frame, display: false)
+        window.alphaValue = CGFloat(alpha)
+        window.orderFrontRegardless()
+    }
+
+    func remove(for displayID: CGDirectDisplayID) {
+        windows.removeValue(forKey: displayID)?.orderOut(nil)
+    }
+
+    func removeAll() {
+        for window in windows.values { window.orderOut(nil) }
+        windows.removeAll()
+    }
+
+    /// Drops overlays for displays that no longer exist and re-fits the rest to their screen's
+    /// current frame. Call after any topology change — a resolution switch or rearrangement moves
+    /// the screen out from under the window.
+    func reconcile() {
+        for (displayID, window) in windows {
+            if let screen = Self.screen(for: displayID) {
+                window.setFrame(screen.frame, display: false)
+            } else {
+                remove(for: displayID)
+            }
+        }
+    }
+
+    private func makeWindow(on screen: NSScreen) -> NSWindow {
+        let window = NSWindow(
+            contentRect: screen.frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.backgroundColor = .black
+        window.isOpaque = false
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.isReleasedWhenClosed = false
+        // Below statusBar: normal windows and the Dock dim; the menu bar and our popover do not.
+        window.level = NSWindow.Level(rawValue: NSWindow.Level.statusBar.rawValue - 1)
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        window.sharingType = .none
+        window.animationBehavior = .none
+        window.setAccessibilityElement(false)
+        return window
+    }
+
+    private static func screen(for displayID: CGDirectDisplayID) -> NSScreen? {
+        NSScreen.screens.first {
+            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+                == displayID
+        }
+    }
+}

--- a/Apps/OpenDisplay/Sources/DisplayDetailView.swift
+++ b/Apps/OpenDisplay/Sources/DisplayDetailView.swift
@@ -3,6 +3,7 @@ import AutomationSchema
 import DisplayDomain
 import OpenDisplayDesignSystem
 import SwiftUI
+import TopologyCore
 
 /// The per-display detail pane (Settings → Displays). This is where everything that used to crowd the
 /// menu-bar card now lives: resolution & refresh, appearance (rotation/colour), hardware controls,
@@ -346,19 +347,47 @@ private struct DimmingCard: View {
     @EnvironmentObject private var model: AppModel
     let display: DisplayObservation
 
+    /// Gamma alone bottoms out at its floor; the overlay methods can keep going (still capped short
+    /// of full black by the composer).
+    private var range: ClosedRange<Double> {
+        model.settings.dimmingMethod == .gamma ? 0.15...1 : 0...1
+    }
+
+    private var footnote: String {
+        switch model.settings.dimmingMethod {
+        case .gamma:
+            return "Software gamma dim, applied on top of brightness. Works on any display, "
+                + "including below the hardware minimum."
+        case .overlay:
+            return "A black overlay at adjustable opacity, applied on top of brightness. Works on "
+                + "any display; the menu bar stays visible so you can always find your way back."
+        case .combined:
+            return "Gamma dim first, then a black overlay on top \u{2014} darker than either method "
+                + "alone, and still never fully black."
+        }
+    }
+
     var body: some View {
-        ODCard(title: "Dimming",
-               footnote: "Software gamma dim, applied on top of brightness. Works on any display, "
-               + "including below the hardware minimum.") {
+        ODCard(title: "Dimming", footnote: footnote) {
             ODRow("Software dimming") {
                 HStack(spacing: 8) {
                     Slider(value: Binding(get: { Double(model.softwareDim[display.recordID] ?? 1) },
-                                          set: { model.setSoftwareDim(Float($0), for: display) }), in: 0.15...1)
+                                          set: { model.setSoftwareDim(Float($0), for: display) }), in: range)
                         .frame(width: 160)
                     Text("\(Int(((model.softwareDim[display.recordID] ?? 1) * 100).rounded()))%")
                         .font(.system(size: 11)).monospacedDigit().foregroundStyle(.secondary)
                         .frame(width: 34, alignment: .trailing)
                 }
+            }
+            ODRow("Method") {
+                Picker("", selection: Binding(
+                    get: { model.settings.dimmingMethod },
+                    set: { model.setDimmingMethod($0) })) {
+                    Text("Gamma").tag(DimmingMethod.gamma)
+                    Text("Overlay").tag(DimmingMethod.overlay)
+                    Text("Combined").tag(DimmingMethod.combined)
+                }
+                .pickerStyle(.segmented).labelsHidden().fixedSize()
             }
         }
     }

--- a/Packages/TopologyCore/Sources/TopologyCore/Dimming.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/Dimming.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// How the software dimming slider darkens a display beyond (or instead of) its backlight.
+public enum DimmingMethod: String, Codable, Sendable, CaseIterable {
+    /// Scale the gamma table (the original behavior). Dims everything including the menu bar, but
+    /// bottoms out at the provider's 0.15 floor.
+    case gamma
+    /// A black, click-through overlay window at adjustable opacity. Independent of the gamma table
+    /// (so it composes with software brightness), capped below full black.
+    case overlay
+    /// Gamma first, then overlay on top — darker than either alone.
+    case combined
+}
+
+/// Splits one dim level into its gamma and overlay components. Pure so the darkness curve — floors,
+/// caps, and the combined handoff point — is unit-tested; the app just applies the two outputs.
+public enum DimmingComposer {
+    /// Gamma scale never goes below this (matches the provider's floor) so a gamma-only dim can't
+    /// black out a display.
+    public static let gammaFloor: Float = 0.15
+    /// The overlay never becomes fully opaque, so even maximum combined dimming leaves the screen
+    /// faintly visible and the user can always find their way back.
+    public static let overlayAlphaCap: Float = 0.9
+    /// In `.combined`, the fraction of the strength range the gamma channel absorbs before the
+    /// overlay starts stacking on top.
+    public static let combinedGammaShare: Float = 0.55
+
+    public struct Split: Equatable, Sendable {
+        /// Gamma scale to apply, `gammaFloor`...1 (1 = untouched).
+        public let gammaLevel: Float
+        /// Overlay opacity to apply, 0...`overlayAlphaCap` (0 = no overlay window).
+        public let overlayAlpha: Float
+
+        public init(gammaLevel: Float, overlayAlpha: Float) {
+            self.gammaLevel = gammaLevel
+            self.overlayAlpha = overlayAlpha
+        }
+    }
+
+    /// `level` is the dim slider's value, 1 (no dimming) down to 0 (maximum), clamped.
+    public static func split(method: DimmingMethod, level: Float) -> Split {
+        let level = min(max(level, 0), 1)
+        let strength = 1 - level
+        switch method {
+        case .gamma:
+            return Split(gammaLevel: max(level, gammaFloor), overlayAlpha: 0)
+        case .overlay:
+            return Split(gammaLevel: 1, overlayAlpha: strength * overlayAlphaCap)
+        case .combined:
+            let gammaPortion = min(strength / combinedGammaShare, 1)
+            let overlayPortion = max(0, (strength - combinedGammaShare) / (1 - combinedGammaShare))
+            return Split(
+                gammaLevel: max(1 - gammaPortion * (1 - gammaFloor), gammaFloor),
+                overlayAlpha: overlayPortion * overlayAlphaCap)
+        }
+    }
+}

--- a/Packages/TopologyCore/Sources/TopologyCore/SettingsStore.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/SettingsStore.swift
@@ -73,6 +73,8 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
     /// When on, ask GitHub for the newest release at most once a day and surface it in the menu.
     /// Manual "Check for updates" works regardless. Nothing is ever downloaded automatically.
     public var updateCheckEnabled: Bool
+    /// How the software dimming slider darkens a display (gamma table, overlay window, or both).
+    public var dimmingMethod: DimmingMethod
 
     public init(
         persistencePolicy: PersistencePolicy = .reconnectOnQuit,
@@ -99,7 +101,8 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         adaptiveEveningPreset: Int = 4,
         adaptiveDayPresetByDisplay: [String: Int] = [:],
         adaptiveBrightnessOffsetByDisplay: [String: Float] = [:],
-        updateCheckEnabled: Bool = true
+        updateCheckEnabled: Bool = true,
+        dimmingMethod: DimmingMethod = .gamma
     ) {
         self.persistencePolicy = persistencePolicy
         self.confirmationCountdownSeconds = confirmationCountdownSeconds
@@ -126,6 +129,7 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         self.adaptiveDayPresetByDisplay = adaptiveDayPresetByDisplay
         self.adaptiveBrightnessOffsetByDisplay = adaptiveBrightnessOffsetByDisplay
         self.updateCheckEnabled = updateCheckEnabled
+        self.dimmingMethod = dimmingMethod
     }
 
     public static let `default` = OpenDisplaySettings()
@@ -154,6 +158,7 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
         case adaptiveDayPresetByDisplay
         case adaptiveBrightnessOffsetByDisplay
         case updateCheckEnabled
+        case dimmingMethod
     }
 
     /// Tolerant decoder: every missing key falls back to its default and unknown keys are ignored,
@@ -229,6 +234,8 @@ public struct OpenDisplaySettings: Hashable, Sendable, Codable {
             ?? defaults.adaptiveBrightnessOffsetByDisplay
         updateCheckEnabled = try container.decodeIfPresent(Bool.self, forKey: .updateCheckEnabled)
             ?? defaults.updateCheckEnabled
+        dimmingMethod = try container.decodeIfPresent(DimmingMethod.self, forKey: .dimmingMethod)
+            ?? defaults.dimmingMethod
     }
 }
 

--- a/Packages/TopologyCore/Tests/TopologyCoreTests/DimmingTests.swift
+++ b/Packages/TopologyCore/Tests/TopologyCoreTests/DimmingTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import TopologyCore
+
+final class DimmingTests: XCTestCase {
+    // MARK: - Gamma method
+
+    func testGammaNoDimIsIdentity() {
+        XCTAssertEqual(DimmingComposer.split(method: .gamma, level: 1),
+                       .init(gammaLevel: 1, overlayAlpha: 0))
+    }
+
+    func testGammaPassesLevelThrough() {
+        XCTAssertEqual(DimmingComposer.split(method: .gamma, level: 0.5),
+                       .init(gammaLevel: 0.5, overlayAlpha: 0))
+    }
+
+    func testGammaRespectsFloor() {
+        let split = DimmingComposer.split(method: .gamma, level: 0)
+        XCTAssertEqual(split.gammaLevel, DimmingComposer.gammaFloor)
+        XCTAssertEqual(split.overlayAlpha, 0)
+    }
+
+    // MARK: - Overlay method
+
+    func testOverlayLeavesGammaAlone() {
+        let split = DimmingComposer.split(method: .overlay, level: 0.3)
+        XCTAssertEqual(split.gammaLevel, 1)
+        XCTAssertEqual(split.overlayAlpha, 0.7 * DimmingComposer.overlayAlphaCap, accuracy: 0.001)
+    }
+
+    func testOverlayMaxIsCappedBelowOpaque() {
+        let split = DimmingComposer.split(method: .overlay, level: 0)
+        XCTAssertEqual(split.overlayAlpha, DimmingComposer.overlayAlphaCap)
+        XCTAssertLessThan(split.overlayAlpha, 1)
+    }
+
+    func testOverlayNoDimHasNoWindow() {
+        XCTAssertEqual(DimmingComposer.split(method: .overlay, level: 1).overlayAlpha, 0)
+    }
+
+    // MARK: - Combined method
+
+    func testCombinedNoDimIsIdentity() {
+        XCTAssertEqual(DimmingComposer.split(method: .combined, level: 1),
+                       .init(gammaLevel: 1, overlayAlpha: 0))
+    }
+
+    func testCombinedGammaLeadsOverlay() {
+        // Inside the gamma share, only gamma moves.
+        let early = DimmingComposer.split(method: .combined, level: 0.7)  // strength 0.3 < 0.55
+        XCTAssertLessThan(early.gammaLevel, 1)
+        XCTAssertEqual(early.overlayAlpha, 0)
+    }
+
+    func testCombinedOverlayJoinsAfterHandoff() {
+        let late = DimmingComposer.split(method: .combined, level: 0.2)  // strength 0.8 > 0.55
+        XCTAssertEqual(late.gammaLevel, DimmingComposer.gammaFloor)
+        XCTAssertGreaterThan(late.overlayAlpha, 0)
+    }
+
+    func testCombinedMaxHitsBothLimits() {
+        let split = DimmingComposer.split(method: .combined, level: 0)
+        XCTAssertEqual(split.gammaLevel, DimmingComposer.gammaFloor)
+        XCTAssertEqual(split.overlayAlpha, DimmingComposer.overlayAlphaCap)
+    }
+
+    func testCombinedGoesDarkerThanGammaAlone() {
+        // Same slider position: combined must remove at least as much light as gamma-only, and at
+        // the bottom of the range strictly more (the overlay stacks past the gamma floor).
+        let gammaOnly = DimmingComposer.split(method: .gamma, level: 0)
+        let combined = DimmingComposer.split(method: .combined, level: 0)
+        let gammaLight = gammaOnly.gammaLevel * (1 - gammaOnly.overlayAlpha)
+        let combinedLight = combined.gammaLevel * (1 - combined.overlayAlpha)
+        XCTAssertLessThan(combinedLight, gammaLight)
+    }
+
+    // MARK: - Monotonicity + clamping
+
+    func testDarknessIsMonotonicInEveryMethod() {
+        for method in DimmingMethod.allCases {
+            var previousLight: Float = .greatestFiniteMagnitude
+            for step in stride(from: Float(1), through: 0, by: -0.05) {
+                let split = DimmingComposer.split(method: method, level: step)
+                let light = split.gammaLevel * (1 - split.overlayAlpha)
+                XCTAssertLessThanOrEqual(light, previousLight + 0.0001,
+                                         "\(method) got brighter as the slider went down at \(step)")
+                previousLight = light
+            }
+        }
+    }
+
+    func testOutOfRangeLevelsClamp() {
+        XCTAssertEqual(DimmingComposer.split(method: .gamma, level: 2),
+                       DimmingComposer.split(method: .gamma, level: 1))
+        XCTAssertEqual(DimmingComposer.split(method: .combined, level: -1),
+                       DimmingComposer.split(method: .combined, level: 0))
+    }
+}


### PR DESCRIPTION
Parity-map §1: overlay dimming + combined (gamma+overlay) dimming, darker than gamma alone.

- **DimmingComposer** (pure, 13 tests): per-method gamma/overlay split, monotonic darkness, floor/cap invariants (never fully black — the composer caps overlay at 0.9 and gamma at 0.15, so a dim can't become an accidental blackout).
- **DimOverlayController**: black click-through windows below the status-bar level (menu bar + popover never dim away), screen-capture-excluded, process-bound (no quit restore needed), reconciled on every topology change.
- Method picker in the Dimming card; live dims re-express on switch.

314 package tests green; both app schemes build.
