### PR TITLE
Add software colour temperature control

### DIFF
--- a/Apps/OpenDisplay/Sources/AppModel.swift
+++ b/Apps/OpenDisplay/Sources/AppModel.swift
@@ -552,14 +552,40 @@ final class AppModel: ObservableObject {
     func setSoftwareDim(_ level: Float, for observation: DisplayObservation) {
         guard let cgID = observation.cgDisplayID else { return }
         softwareDim[observation.recordID] = level
-        applyDim(level: level, cgID: cgID)
+        applyDim(level: level, id: observation.recordID, cgID: cgID)
     }
 
     /// Expresses one dim level through the current method's gamma/overlay split.
-    private func applyDim(level: Float, cgID: CGDirectDisplayID) {
+    private func applyDim(level: Float, id: DisplayRecordID, cgID: CGDirectDisplayID) {
         let split = DimmingComposer.split(method: settings.dimmingMethod, level: level)
-        observer.setGammaDim(split.gammaLevel, for: cgID)
+        writeGamma(level: split.gammaLevel, id: id, cgID: cgID)
         dimOverlay.setAlpha(split.overlayAlpha, for: cgID)
+    }
+
+    /// Per-display software colour temperature in kelvin; absent = neutral (calibration untouched).
+    /// Session-only, like the software dim — `restoreGamma` on quit clears both.
+    @Published private(set) var colorTemperature: [DisplayRecordID: Float] = [:]
+
+    /// Sets the display's software colour temperature and re-expresses the gamma slot, which the
+    /// warmth gains share with the dim scale — one formula per display, so both go in together.
+    func setColorTemperature(_ kelvin: Float, for observation: DisplayObservation) {
+        guard let cgID = observation.cgDisplayID else { return }
+        let id = observation.recordID
+        // Snap to native near the neutral point so a slider drag can actually land on "untouched".
+        colorTemperature[id] = abs(kelvin - ColorTemperatureCurve.neutralKelvin) < 100 ? nil : kelvin
+        guard !blackedOut.contains(id) else { return }  // applied when the blackout lifts
+        let split = DimmingComposer.split(method: settings.dimmingMethod, level: softwareDim[id] ?? 1)
+        writeGamma(level: split.gammaLevel, id: id, cgID: cgID)
+    }
+
+    /// The one funnel for gamma writes: dim scale × the display's colour-temperature gains. Direct
+    /// `setGammaDim` calls would silently clear an active warmth — only Black Out (which wants the
+    /// neutral floor) bypasses this.
+    private func writeGamma(level: Float, id: DisplayRecordID, cgID: CGDirectDisplayID) {
+        let gains = ColorTemperatureCurve.gains(
+            kelvin: colorTemperature[id] ?? ColorTemperatureCurve.neutralKelvin)
+        observer.setGammaAdjustment(
+            dim: level, red: gains.red, green: gains.green, blue: gains.blue, for: cgID)
     }
 
     /// Switches the dimming method and re-expresses every live dim through it, so the slider
@@ -571,7 +597,7 @@ final class AppModel: ObservableObject {
         persistSettings()
         for (id, level) in softwareDim where level < 1.0 && !blackedOut.contains(id) {
             guard let cgID = displays.first(where: { $0.recordID == id })?.cgDisplayID else { continue }
-            applyDim(level: level, cgID: cgID)
+            applyDim(level: level, id: id, cgID: cgID)
         }
     }
 
@@ -591,7 +617,7 @@ final class AppModel: ObservableObject {
         let id = observation.recordID
         if blackedOut.contains(id) {
             blackedOut.remove(id)
-            applyDim(level: softwareDim[id] ?? 1.0, cgID: cgID)
+            applyDim(level: softwareDim[id] ?? 1.0, id: id, cgID: cgID)
         } else {
             blackedOut.insert(id)
             observer.setGammaDim(0.0, for: cgID)
@@ -686,6 +712,9 @@ final class AppModel: ObservableObject {
         if !inputSource.keys.allSatisfy(ids.contains) { inputSource = inputSource.filter { ids.contains($0.key) } }
         if !colorProfileName.keys.allSatisfy(ids.contains) { colorProfileName = colorProfileName.filter { ids.contains($0.key) } }
         if !softwareDim.keys.allSatisfy(ids.contains) { softwareDim = softwareDim.filter { ids.contains($0.key) } }
+        if !colorTemperature.keys.allSatisfy(ids.contains) {
+            colorTemperature = colorTemperature.filter { ids.contains($0.key) }
+        }
         dimOverlay.reconcile()  // drop overlays for departed displays, re-fit after mode/layout changes
         if !colorProfileControllable.keys.allSatisfy(ids.contains) { colorProfileControllable = colorProfileControllable.filter { ids.contains($0.key) } }
         if !blackedOut.allSatisfy(ids.contains) { blackedOut = blackedOut.filter(ids.contains) }
@@ -809,7 +838,7 @@ final class AppModel: ObservableObject {
                     // dark no matter where the (now hardware) slider sits. Never while Black Out
                     // holds the panel at gamma 0 — a background refresh must not light it up.
                     if let dim = softwareDim[id], dim < 1.0, !blackedOut.contains(id) {
-                        observer.setGammaDim(1.0, for: cgID)
+                        writeGamma(level: 1.0, id: id, cgID: cgID)  // keep any warmth, clear the dim
                         dimOverlay.remove(for: cgID)
                         softwareDim[id] = nil
                     }
@@ -869,7 +898,7 @@ final class AppModel: ObservableObject {
         case .software:
             let gamma = max(0.15, value)
             softwareDim[id] = gamma
-            observer.setGammaDim(gamma, for: cgID)
+            writeGamma(level: gamma, id: id, cgID: cgID)  // brightness emulation keeps the warmth
         }
         presentOSD(kind: .brightness, value: value, for: observation)  // Batch-3 #4
     }
@@ -1120,7 +1149,7 @@ final class AppModel: ObservableObject {
     private func reapplySoftwareDim(for observation: DisplayObservation) {
         guard let cgID = observation.cgDisplayID, !blackedOut.contains(observation.recordID),
               let dim = softwareDim[observation.recordID], dim < 1.0 else { return }
-        applyDim(level: dim, cgID: cgID)
+        applyDim(level: dim, id: observation.recordID, cgID: cgID)
     }
 
     /// Current rotation of a display in degrees (0/90/180/270), read via public Core Graphics.

--- a/Apps/OpenDisplay/Sources/DisplayDetailView.swift
+++ b/Apps/OpenDisplay/Sources/DisplayDetailView.swift
@@ -211,8 +211,28 @@ private struct AppearanceCard: View {
     @EnvironmentObject private var model: AppModel
     let display: DisplayObservation
 
+    /// Displayed kelvin for the temperature slider (absent cache = neutral).
+    private var temperature: Float {
+        model.colorTemperature[display.recordID] ?? ColorTemperatureCurve.neutralKelvin
+    }
+
     var body: some View {
         ODCard(title: "Appearance") {
+            ODRow("Colour temperature") {
+                HStack(spacing: 8) {
+                    Image(systemName: "thermometer.sun").font(.system(size: 11)).foregroundStyle(.orange)
+                    Slider(value: Binding(get: { Double(temperature) },
+                                          set: { model.setColorTemperature(Float($0), for: display) }),
+                           in: Double(ColorTemperatureCurve.minKelvin)...Double(ColorTemperatureCurve.maxKelvin))
+                        .frame(width: 140)
+                    Image(systemName: "thermometer.snowflake").font(.system(size: 11)).foregroundStyle(.cyan)
+                    Text(model.colorTemperature[display.recordID] == nil
+                         ? "Native" : "\(Int(temperature)) K")
+                        .font(.system(size: 11)).monospacedDigit().foregroundStyle(.secondary)
+                        .frame(width: 48, alignment: .trailing)
+                }
+            }
+            ODDivider()
             ODRow("Rotation") {
                 if model.rotationWritable {
                     HStack(spacing: 6) {

--- a/Packages/TopologyCore/Sources/TopologyCore/ColorTemperature.swift
+++ b/Packages/TopologyCore/Sources/TopologyCore/ColorTemperature.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Converts a colour temperature in kelvin into per-channel gamma gains, for the software
+/// warm/cool control. Built on the Tanner Helland blackbody approximation, expressed *relative to
+/// the neutral point* so `neutralKelvin` is exactly (1, 1, 1) — the display's calibration is
+/// untouched at neutral — and every other temperature only ever attenuates channels (gains ≤ 1,
+/// dominant channel pinned to 1) so highlights never clip.
+public enum ColorTemperatureCurve {
+    /// Identity — the display's own calibration.
+    public static let neutralKelvin: Float = 6500
+    /// Candle-light warm; matches the bottom of typical night-mode ranges.
+    public static let minKelvin: Float = 2700
+    /// Strongly blue; the cool end of common display presets.
+    public static let maxKelvin: Float = 9300
+
+    public struct Gains: Equatable, Sendable {
+        public let red: Float
+        public let green: Float
+        public let blue: Float
+
+        public init(red: Float, green: Float, blue: Float) {
+            self.red = red
+            self.green = green
+            self.blue = blue
+        }
+
+        public static let neutral = Gains(red: 1, green: 1, blue: 1)
+    }
+
+    /// Gains for `kelvin` (clamped to `minKelvin...maxKelvin`).
+    public static func gains(kelvin: Float) -> Gains {
+        let kelvin = min(max(kelvin, minKelvin), maxKelvin)
+        if kelvin == neutralKelvin { return .neutral }
+        let target = blackbody(kelvin: Double(kelvin))
+        let neutral = blackbody(kelvin: Double(neutralKelvin))
+        // Relative correction from neutral, renormalised so the dominant channel stays at 1.
+        var r = target.r / neutral.r
+        var g = target.g / neutral.g
+        var b = target.b / neutral.b
+        let peak = max(r, g, b)
+        r /= peak
+        g /= peak
+        b /= peak
+        return Gains(red: Float(r), green: Float(g), blue: Float(b))
+    }
+
+    /// Tanner Helland's kelvin → RGB fit (0...255 per channel), the standard screen-warmth curve.
+    private static func blackbody(kelvin: Double) -> (r: Double, g: Double, b: Double) {
+        let t = kelvin / 100
+        let r: Double
+        let g: Double
+        let b: Double
+        if t <= 66 {
+            r = 255
+            g = 99.4708025861 * log(t) - 161.1195681661
+        } else {
+            r = 329.698727446 * pow(t - 60, -0.1332047592)
+            g = 288.1221695283 * pow(t - 60, -0.0755148492)
+        }
+        if t >= 66 {
+            b = 255
+        } else if t <= 19 {
+            b = 0
+        } else {
+            b = 138.5177312231 * log(t - 10) - 305.0447927307
+        }
+        return (min(max(r, 0), 255), min(max(g, 0), 255), min(max(b, 0), 255))
+    }
+}

--- a/Packages/TopologyCore/Tests/TopologyCoreTests/ColorTemperatureTests.swift
+++ b/Packages/TopologyCore/Tests/TopologyCoreTests/ColorTemperatureTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import TopologyCore
+
+final class ColorTemperatureTests: XCTestCase {
+    func testNeutralIsExactIdentity() {
+        XCTAssertEqual(ColorTemperatureCurve.gains(kelvin: 6500), .neutral)
+    }
+
+    func testWarmAttenuatesBlueKeepsRed() {
+        let gains = ColorTemperatureCurve.gains(kelvin: 3000)
+        XCTAssertEqual(gains.red, 1, accuracy: 0.0001)
+        XCTAssertLessThan(gains.blue, gains.green)
+        XCTAssertLessThan(gains.green, 1)
+        XCTAssertGreaterThan(gains.blue, 0)  // warm, not yellow-only — blue never vanishes entirely
+    }
+
+    func testCoolAttenuatesRedKeepsBlue() {
+        let gains = ColorTemperatureCurve.gains(kelvin: 9000)
+        XCTAssertEqual(gains.blue, 1, accuracy: 0.0001)
+        XCTAssertLessThan(gains.red, 1)
+    }
+
+    func testGainsNeverExceedOne() {
+        for kelvin in stride(from: Float(2700), through: 9300, by: 100) {
+            let gains = ColorTemperatureCurve.gains(kelvin: kelvin)
+            XCTAssertLessThanOrEqual(gains.red, 1)
+            XCTAssertLessThanOrEqual(gains.green, 1)
+            XCTAssertLessThanOrEqual(gains.blue, 1)
+            XCTAssertEqual(max(gains.red, gains.green, gains.blue), 1, accuracy: 0.0001,
+                           "dominant channel must stay pinned at 1 (\(kelvin)K)")
+        }
+    }
+
+    func testBlueIsMonotonicInKelvinOnTheWarmSide() {
+        var previous: Float = -1
+        for kelvin in stride(from: Float(2700), through: 6500, by: 100) {
+            let blue = ColorTemperatureCurve.gains(kelvin: kelvin).blue
+            XCTAssertGreaterThanOrEqual(blue, previous, "warmer should mean less blue (\(kelvin)K)")
+            previous = blue
+        }
+    }
+
+    func testClampsOutOfRangeKelvin() {
+        XCTAssertEqual(ColorTemperatureCurve.gains(kelvin: 1000),
+                       ColorTemperatureCurve.gains(kelvin: ColorTemperatureCurve.minKelvin))
+        XCTAssertEqual(ColorTemperatureCurve.gains(kelvin: 20000),
+                       ColorTemperatureCurve.gains(kelvin: ColorTemperatureCurve.maxKelvin))
+    }
+}

--- a/Providers/CoreGraphicsProvider/Sources/CoreGraphicsProvider.swift
+++ b/Providers/CoreGraphicsProvider/Sources/CoreGraphicsProvider.swift
@@ -163,8 +163,21 @@ public actor CoreGraphicsProvider: TopologyObserving, DisplayProvider, Lifecycle
     /// dim). Works on any display — including externals without DDC and below the hardware minimum.
     /// Floored so the screen can never go fully black. Public Core Graphics (CGSetDisplayTransferByFormula).
     public nonisolated func setGammaDim(_ level: Float, for displayID: CGDirectDisplayID) {
-        let scale = CGGammaValue(max(0.15, min(1, level)))
-        _ = CGSetDisplayTransferByFormula(displayID, 0, scale, 1, 0, scale, 1, 0, scale, 1)
+        setGammaAdjustment(dim: level, red: 1, green: 1, blue: 1, for: displayID)
+    }
+
+    /// The combined software gamma write: one dim scale times per-channel colour-temperature gains
+    /// (each 0...1). Dim and warmth share the single `CGSetDisplayTransferByFormula` slot per
+    /// display, so every gamma-touching path must come through here (or `setGammaDim`, its
+    /// neutral-colour wrapper) — separate calls would silently overwrite each other.
+    public nonisolated func setGammaAdjustment(
+        dim: Float, red: Float, green: Float, blue: Float, for displayID: CGDirectDisplayID
+    ) {
+        let scale = CGGammaValue(max(0.15, min(1, dim)))
+        let r = scale * CGGammaValue(min(max(red, 0), 1))
+        let g = scale * CGGammaValue(min(max(green, 0), 1))
+        let b = scale * CGGammaValue(min(max(blue, 0), 1))
+        _ = CGSetDisplayTransferByFormula(displayID, 0, r, 1, 0, g, 1, 0, b, 1)
     }
 
     /// Restores every display's gamma to its ColorSync calibration, clearing any software dim. Call


### PR DESCRIPTION
Parity-map §3: warm/cool control via the existing gamma path.

- **ColorTemperatureCurve** (pure, 6 tests): Helland blackbody fit normalised to the 6500 K neutral — identity at neutral, attenuation-only gains, monotonic blue on the warm side.
- **One gamma funnel:** dim × warmth now go through a single `setGammaAdjustment` write; every path that used to call `setGammaDim` directly (software brightness, dim lift, profile reapply) preserves an active warmth instead of silently clearing it.
- Warm/cool slider in the Appearance card, snaps to "Native" near 6500 K.

321 package tests green; both app schemes build.
