### PR TITLE
Add custom About window; fix pop-out keyboard focus

### DIFF
--- a/Apps/OpenDisplay/Sources/AboutView.swift
+++ b/Apps/OpenDisplay/Sources/AboutView.swift
@@ -1,0 +1,102 @@
+#if os(macOS)
+import AppKit
+import OpenDisplayDesignSystem
+import SwiftUI
+
+/// Custom About window, replacing `orderFrontStandardAboutPanel`. The standard panel only shows
+/// the icon + version; this one adds what people actually come for — the running version (selectable
+/// for bug reports), an update check, and links to the project. Accessibility: semantic fonts (respect
+/// the user's text-size setting), real `Link` controls (focusable, VoiceOver-labelled), and the
+/// decorative icon hidden from assistive tech.
+struct AboutView: View {
+    @EnvironmentObject private var model: AppModel
+
+    private static let repo = "https://github.com/aquitaine/OpenDisplay"
+
+    private var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+    }
+    private var build: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+    }
+
+    var body: some View {
+        VStack(spacing: ODSpacing.sm) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable().frame(width: 64, height: 64)
+                .accessibilityHidden(true)
+            Text("OpenDisplay")
+                .font(.title2.weight(.semibold))
+            Text("Free, open-source display control for macOS.")
+                .font(.callout).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Version \(version) (build \(build))")
+                .font(.callout.monospacedDigit())
+                .textSelection(.enabled)
+                .accessibilityLabel("Version \(version), build \(build)")
+                .padding(.top, 2)
+            updateStatus
+
+            Divider().padding(.vertical, ODSpacing.xs)
+
+            VStack(alignment: .leading, spacing: ODSpacing.sm) {
+                aboutLink("Website", systemImage: "globe", url: Self.repo)
+                aboutLink("Release notes", systemImage: "doc.text", url: "\(Self.repo)/releases")
+                aboutLink("Report an issue", systemImage: "ladybug", url: "\(Self.repo)/issues/new")
+                aboutLink("License (GPL-3.0)", systemImage: "checkmark.seal",
+                          url: "\(Self.repo)/blob/main/LICENSE")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, ODSpacing.lg)
+
+            Text("© 2026 OpenDisplay contributors")
+                .font(.footnote).foregroundStyle(.tertiary)
+                .padding(.top, ODSpacing.xs)
+        }
+        .padding(.vertical, ODSpacing.xl)
+        .padding(.horizontal, ODSpacing.xl)
+        .frame(width: 300)
+    }
+
+    /// Mirrors the menu's update row: idle → button, checking → progress, result → outcome text
+    /// (with a click-through to the release page when one is available).
+    @ViewBuilder private var updateStatus: some View {
+        switch model.updateState {
+        case .idle:
+            Button("Check for Updates…") { Task { await model.checkForUpdates() } }
+                .controlSize(.small)
+        case .checking:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Checking for updates…").font(.callout).foregroundStyle(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+        case .upToDate:
+            Label("Up to date", systemImage: "checkmark.circle")
+                .font(.callout).foregroundStyle(.secondary)
+        case .available(let version, _):
+            Button {
+                model.openUpdatePage()
+            } label: {
+                Label("Update available: \(version)", systemImage: "arrow.down.circle.fill")
+            }
+            .controlSize(.small)
+            .accessibilityHint("Opens the release page in your browser")
+        }
+    }
+
+    private func aboutLink(_ title: String, systemImage: String, url: String) -> some View {
+        Link(destination: URL(string: url)!) {
+            Label {
+                Text(title).font(.callout)
+            } icon: {
+                Image(systemName: systemImage).frame(width: 18)
+            }
+        }
+        .foregroundStyle(ODColor.accent)
+        .accessibilityHint("Opens in your browser")
+    }
+}
+#endif

--- a/Apps/OpenDisplay/Sources/MenuBarView.swift
+++ b/Apps/OpenDisplay/Sources/MenuBarView.swift
@@ -87,16 +87,15 @@ struct MenuBarView: View {
                 ))
                 Divider()
                 Button("About OpenDisplay") {
-                    NSApp.activate(ignoringOtherApps: true)
-                    NSApp.orderFrontStandardAboutPanel(nil)
+                    NotificationCenter.default.post(name: .openDisplayShowAbout, object: nil)
                 }
                 Divider()
                 Button("Quit OpenDisplay") { NSApp.terminate(nil) }
             } label: {
                 Image(systemName: "ellipsis.circle").font(.system(size: 15))
             }
-            .buttonStyle(.plain).foregroundStyle(.secondary)
-            .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+            .menuStyle(.button).buttonStyle(.plain).foregroundStyle(.secondary)
+            .menuIndicator(.hidden).fixedSize()
             .accessibilityLabel("More options")
         }
         .padding(.horizontal, 6).padding(.top, 2).padding(.bottom, 2)

--- a/Apps/OpenDisplay/Sources/OpenDisplayApp.swift
+++ b/Apps/OpenDisplay/Sources/OpenDisplayApp.swift
@@ -31,6 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private let popover = NSPopover()
     private var settingsWindow: NSWindow?
+    private var aboutWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         popover.behavior = .transient
@@ -48,6 +49,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // that window, not SwiftUI) so it reliably appears on the screen the user is looking at.
         NotificationCenter.default.addObserver(
             self, selector: #selector(showSettings), name: .openDisplayShowSettings, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(showAbout), name: .openDisplayShowAbout, object: nil)
 
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.button?.image = NSImage(systemSymbolName: "display", accessibilityDescription: "OpenDisplay")
@@ -62,7 +65,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             popover.performClose(sender)
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
+            guard let window = popover.contentViewController?.view.window else { return }
+            window.makeKey()
+            // AppKit hands initial key focus to the first control (the gear button), which paints an
+            // accent focus ring the moment the pop-out opens. Clear it — Tab still reaches every
+            // control for keyboard users; the ring just doesn't appear until they ask for it.
+            DispatchQueue.main.async { window.makeFirstResponder(nil) }
         }
     }
 
@@ -86,6 +94,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             created.isReleasedWhenClosed = false
             created.setContentSize(NSSize(width: 720, height: 520))
             settingsWindow = created
+            window = created
+        }
+        if let screen = NSScreen.screens.first(where: {
+            NSMouseInRect(NSEvent.mouseLocation, $0.frame, false)
+        }) ?? NSScreen.main {
+            let visible = screen.visibleFrame
+            let size = window.frame.size
+            window.setFrameOrigin(NSPoint(x: visible.midX - size.width / 2,
+                                          y: visible.midY - size.height / 2))
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    /// Opens (or re-focuses) the custom About window (`AboutView`) — same ownership story as
+    /// Settings: an AppKit window the delegate places on the screen the user is looking at.
+    @objc private func showAbout() {
+        dismissPopover()
+        let window: NSWindow
+        if let existing = aboutWindow {
+            window = existing
+        } else {
+            let hosting = NSHostingController(rootView: AboutView().environmentObject(model))
+            let created = NSWindow(contentViewController: hosting)
+            created.title = "About OpenDisplay"
+            created.styleMask = [.titled, .closable]
+            created.isReleasedWhenClosed = false
+            aboutWindow = created
             window = created
         }
         if let screen = NSScreen.screens.first(where: {
@@ -127,5 +163,7 @@ extension Notification.Name {
     /// Posted by the menu's gear / "Displays & arrangement…" rows to ask the delegate to open the
     /// Settings window (AppKit-owned, so it lands on the screen the user clicked from).
     static let openDisplayShowSettings = Notification.Name("OpenDisplayShowSettings")
+    /// Posted by the menu's "About OpenDisplay" item; the delegate owns the About window.
+    static let openDisplayShowAbout = Notification.Name("OpenDisplayShowAbout")
 }
 #endif


### PR DESCRIPTION
## Summary
- Replaces the standard About panel with a proper About window: live version/build from the bundle (selectable), an update check reusing the existing checker state, and links to the website, release notes, issue tracker, and license — with VoiceOver labels/hints and semantic (user-scalable) fonts.
- The menu pop-out no longer opens with a focus ring already drawn on the gear button (initial first responder is cleared after show; Tab still reaches everything).
- Forward Tab no longer gets stuck after the "More options" button — the deprecated `.borderlessButton` menu style broke the key loop. Tab now cycles forward through every control and wraps, matching Shift-Tab.

## Test plan
- `make test` green (321 tests); OpenDisplay and OpenDisplay-PublicAPIOnly schemes both build.
- Live-verified via accessibility probes on a Debug bundle: popover opens with no focused control; forward Tab hits all 13 stops and wraps (Quit reached at stop 5 and again at 18); About window opens from the ··· menu showing 0.5.0 (build 6) with working layout in dark mode.
